### PR TITLE
4776 line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,8 +12,6 @@ enable-extensions = TC, TC2
 type-checking-exempt-modules = typing, typing-extensions
 eradicate-whitelist-extend = ^-.*;
 extend-ignore =
-    # E501: Line too long (FIXME: long string constants)
-    E501,
     # E203: Whitespace before ':' (pycqa/pycodestyle#373)
     E203,
     # SIM106: Handle error-cases first

--- a/src/poetry/__init__.py
+++ b/src/poetry/__init__.py
@@ -1,1 +1,4 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore[has-type]
+__path__ = __import__("pkgutil").extend_path(
+    __path__,  # type: ignore[has-type]
+    __name__,
+)

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -10,8 +10,9 @@ from poetry.config.config_source import ConfigSource
 
 
 if TYPE_CHECKING:
-    from poetry.core.toml.file import TOMLFile
     from tomlkit.toml_document import TOMLDocument
+
+    from poetry.core.toml.file import TOMLFile
 
 
 class FileConfigSource(ConfigSource):

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -16,11 +16,11 @@ from cleo.events.event_dispatcher import EventDispatcher
 from cleo.exceptions import CleoException
 from cleo.formatters.style import Style
 from cleo.io.inputs.argv_input import ArgvInput
-from poetry.core.utils._compat import PY37
 
 from poetry.__version__ import __version__
 from poetry.console.command_loader import CommandLoader
 from poetry.console.commands.command import Command
+from poetry.core.utils._compat import PY37
 
 
 if TYPE_CHECKING:
@@ -353,7 +353,7 @@ class Application(BaseApplication):
             SolutionProviderRepository,
         )
 
-        from poetry.mixology.solutions.providers.python_requirement_solution_provider import (
+        from poetry.mixology.solutions.providers.python_requirement_solution_provider import (  # noqa: E501
             PythonRequirementSolutionProvider,
         )
 

--- a/src/poetry/console/commands/about.py
+++ b/src/poetry/console/commands/about.py
@@ -9,8 +9,9 @@ class AboutCommand(Command):
 
     def handle(self) -> None:
         self.line(
-            """<info>Poetry - Package Management for Python</info>
-
-<comment>Poetry is a dependency manager tracking local dependencies of your projects and libraries.
-See <fg=blue>https://github.com/python-poetry/poetry</> for more information.</comment>"""
+            "<info>Poetry - Package Management for Python</info>\n\n"
+            "<comment>Poetry is a dependency manager tracking local dependencies "
+            "of your projects and libraries.\n"
+            "See <fg=blue>https://github.com/python-poetry/poetry</> "
+            "for more information.</comment>"
         )

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -54,33 +54,41 @@ class AddCommand(InstallerCommand, InitCommand):
         option(
             "dry-run",
             None,
-            "Output the operations but do not execute anything (implicitly enables --verbose).",
+            "Output the operations but do not execute anything "
+            "(implicitly enables --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
     ]
-    help = (
-        "The add command adds required packages to your <comment>pyproject.toml</> and installs them.\n\n"
-        "If you do not specify a version constraint, poetry will choose a suitable one based on the available package versions.\n\n"
-        "You can specify a package in the following forms:\n"
-        "  - A single name (<b>requests</b>)\n"
-        "  - A name and a constraint (<b>requests@^2.23.0</b>)\n"
-        "  - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)\n"
-        "  - A git url with a revision (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)\n"
-        "  - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)\n"
-        "  - A git SSH url with a revision (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)\n"
-        "  - A file path (<b>../my-package/my-package.whl</b>)\n"
-        "  - A directory (<b>../my-package/</b>)\n"
-        "  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)\n"
-    )
+
+    help = """\
+The add command adds required packages to your <comment>pyproject.toml</> \
+and installs them.
+
+If you do not specify a version constraint, poetry will choose a suitable one based \
+on the available package versions.
+
+You can specify a package in the following forms:
+  - A single name (<b>requests</b>)
+  - A name and a constraint (<b>requests@^2.23.0</b>)
+  - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
+  - A git url with a revision \
+(<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+  - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)
+  - A git SSH url with a revision \
+(<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
+  - A file path (<b>../my-package/my-package.whl</b>)
+  - A directory (<b>../my-package/</b>)
+  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)
+"""
 
     loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self) -> int:
-        from poetry.core.semver.helpers import parse_constraint
         from tomlkit import inline_table
         from tomlkit import parse as parse_toml
         from tomlkit import table
 
+        from poetry.core.semver.helpers import parse_constraint
         from poetry.factory import Factory
 
         packages = self.argument("name")
@@ -244,11 +252,14 @@ class AddCommand(InstallerCommand, InitCommand):
 
     def notify_about_existing_packages(self, existing_packages: List[str]) -> None:
         self.line(
-            "The following packages are already present in the pyproject.toml and will be skipped:\n"
+            "The following packages are already present in the pyproject.toml "
+            "and will be skipped:\n"
         )
         for name in existing_packages:
             self.line(f"  • <c1>{name}</c1>")
         self.line(
-            "\nIf you want to update it to the latest compatible version, you can use `poetry update package`.\n"
-            "If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.\n"
+            "\nIf you want to update it to the latest compatible version, "
+            "you can use `poetry update package`.\n"
+            "If you prefer to upgrade it to the latest available version, "
+            "you can use `poetry add package@latest`.\n"
         )

--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -10,7 +10,6 @@ class CheckCommand(Command):
 
     def handle(self) -> int:
         from poetry.core.pyproject.toml import PyProjectTOML
-
         from poetry.factory import Factory
 
         # Load poetry config and display errors, if any

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -100,10 +100,9 @@ To remove a repository (repo is a short alias for repositories):
     def handle(self) -> Optional[int]:
         from pathlib import Path
 
+        from poetry.config.file_config_source import FileConfigSource
         from poetry.core.pyproject.exceptions import PyProjectException
         from poetry.core.toml.file import TOMLFile
-
-        from poetry.config.file_config_source import FileConfigSource
         from poetry.factory import Factory
         from poetry.locations import CONFIG_DIR
 

--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -37,8 +37,8 @@ class DebugResolveCommand(InitCommand):
 
     def handle(self) -> Optional[int]:
         from cleo.io.null_io import NullIO
-        from poetry.core.packages.project_package import ProjectPackage
 
+        from poetry.core.packages.project_package import ProjectPackage
         from poetry.factory import Factory
         from poetry.puzzle import Solver
         from poetry.repositories.pool import Pool

--- a/src/poetry/console/commands/env/info.py
+++ b/src/poetry/console/commands/env/info.py
@@ -40,12 +40,15 @@ class EnvInfoCommand(Command):
         listing = [
             f"<info>Python</info>:         <comment>{env_python_version}</>",
             f"<info>Implementation</info>: <comment>{env.python_implementation}</>",
-            f"<info>Path</info>:           <comment>{env.path if env.is_venv() else 'NA'}</>",
-            f"<info>Executable</info>:     <comment>{env.python if env.is_venv() else 'NA'}</>",
+            f"<info>Path</info>:           "
+            f"<comment>{env.path if env.is_venv() else 'NA'}</>",
+            f"<info>Executable</info>:     "
+            f"<comment>{env.python if env.is_venv() else 'NA'}</>",
         ]
         if env.is_venv():
             listing.append(
-                f"<info>Valid</info>:          <{'comment' if env.is_sane() else 'error'}>{env.is_sane()}</>"
+                f"<info>Valid</info>:          "
+                f"<{'comment' if env.is_sane() else 'error'}>{env.is_sane()}</>"
             )
         self.line("\n".join(listing))
 

--- a/src/poetry/console/commands/env/remove.py
+++ b/src/poetry/console/commands/env/remove.py
@@ -12,8 +12,8 @@ class EnvRemoveCommand(Command):
     arguments = [
         argument(
             "python",
-            "The python executables associated with, or names of the virtual environments which are to "
-            "be removed.",
+            "The python executables associated with, or names of the virtual "
+            "environments which are to be removed.",
             optional=True,
             multiple=True,
         )

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -54,7 +54,8 @@ class InitCommand(Command):
     ]
 
     help = """\
-The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the current directory.
+The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file \
+in the current directory.
 """
 
     def __init__(self) -> None:
@@ -67,7 +68,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.vcs.git import GitConfig
-
         from poetry.layouts import layout
         from poetry.utils.env import SystemEnv
 
@@ -76,13 +76,15 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if pyproject.file.exists():
             if pyproject.is_poetry_project():
                 self.line(
-                    "<error>A pyproject.toml file with a poetry section already exists.</error>"
+                    "<error>A pyproject.toml file with a poetry section "
+                    "already exists.</error>"
                 )
                 return 1
 
             if pyproject.data.get("build-system"):
                 self.line(
-                    "<error>A pyproject.toml file with a defined build-system already exists.</error>"
+                    "<error>A pyproject.toml file with a defined build-system "
+                    "already exists.</error>"
                 )
                 return 1
 
@@ -91,7 +93,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if self.io.is_interactive():
             self.line("")
             self.line(
-                "This command will guide you through creating your <info>pyproject.toml</> config."
+                "This command will guide you through "
+                "creating your <info>pyproject.toml</> config."
             )
             self.line("")
 
@@ -165,16 +168,18 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             )
 
         question = "Would you like to define your main dependencies interactively?"
-        help_message = (
-            "You can specify a package in the following forms:\n"
-            "  - A single name (<b>requests</b>)\n"
-            "  - A name and a constraint (<b>requests@^2.23.0</b>)\n"
-            "  - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)\n"
-            "  - A git url with a revision (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)\n"
-            "  - A file path (<b>../my-package/my-package.whl</b>)\n"
-            "  - A directory (<b>../my-package/</b>)\n"
-            "  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)\n"
-        )
+        help_message = """\
+You can specify a package in the following forms:
+  - A single name (<b>requests</b>)
+  - A name and a constraint (<b>requests@^2.23.0</b>)
+  - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
+  - A git url with a revision \
+(<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+  - A file path (<b>../my-package/my-package.whl</b>)
+  - A directory (<b>../my-package/</b>)
+  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)
+"""
+
         help_displayed = False
         if self.confirm(question, True):
             if self.io.is_interactive():
@@ -280,11 +285,13 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         choices.append(found_package.pretty_name)
 
                     self.line(
-                        f"Found <info>{len(matches)}</info> packages matching <c1>{package}</c1>"
+                        f"Found <info>{len(matches)}</info> packages matching "
+                        f"<c1>{package}</c1>"
                     )
 
                     package = self.choice(
-                        "\nEnter package # to add, or the complete package name if it is not listed",
+                        "\nEnter package # to add, or the complete package name "
+                        "if it is not listed",
                         choices,
                         attempts=3,
                     )
@@ -310,7 +317,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         )
 
                         self.line(
-                            f"Using version <b>{package_constraint}</b> for <c1>{package}</c1>"
+                            f"Using version <b>{package_constraint}</b> "
+                            f"for <c1>{package}</c1>"
                         )
 
                     constraint["version"] = package_constraint
@@ -378,7 +386,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
     def _parse_requirements(self, requirements: List[str]) -> List[Dict[str, str]]:
         from poetry.core.pyproject.exceptions import PyProjectException
-
         from poetry.puzzle.provider import Provider
 
         result = []

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -34,17 +34,20 @@ class InstallCommand(InstallerCommand):
         option(
             "no-dev",
             None,
-            "Do not install the development dependencies. (<warning>Deprecated</warning>)",
+            "Do not install the development dependencies. "
+            "(<warning>Deprecated</warning>)",
         ),
         option(
             "dev-only",
             None,
-            "Only install the development dependencies. (<warning>Deprecated</warning>)",
+            "Only install the development dependencies. "
+            "(<warning>Deprecated</warning>)",
         ),
         option(
             "sync",
             None,
-            "Synchronize the environment with the locked packages and the specified groups.",
+            "Synchronize the environment with the locked packages "
+            "and the specified groups.",
         ),
         option(
             "no-root", None, "Do not install the root package (the current project)."
@@ -87,7 +90,6 @@ dependencies and not including the current project, run the command with the
 
     def handle(self) -> int:
         from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
-
         from poetry.masonry.builders import EditableBuilder
 
         self._installer.use_executor(
@@ -108,14 +110,16 @@ dependencies and not including the current project, run the command with the
         only_groups = []
         if self.option("no-dev"):
             self.line(
-                "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is deprecated, "
-                "use the `<fg=yellow;options=bold>--without dev</>` notation instead.</warning>"
+                "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is "
+                "deprecated, use the `<fg=yellow;options=bold>--without dev</>` "
+                "notation instead.</warning>"
             )
             excluded_groups.append("dev")
         elif self.option("dev-only"):
             self.line(
-                "<warning>The `<fg=yellow;options=bold>--dev-only</>` option is deprecated, "
-                "use the `<fg=yellow;options=bold>--only dev</>` notation instead.</warning>"
+                "<warning>The `<fg=yellow;options=bold>--dev-only</>` option is "
+                "deprecated, use the `<fg=yellow;options=bold>--only dev</>` "
+                "notation instead.</warning>"
             )
             only_groups.append("dev")
 
@@ -147,8 +151,9 @@ dependencies and not including the current project, run the command with the
         with_synchronization = self.option("sync")
         if self.option("remove-untracked"):
             self.line(
-                "<warning>The `<fg=yellow;options=bold>--remove-untracked</>` option is deprecated, "
-                "use the `<fg=yellow;options=bold>--sync</>` option instead.</warning>"
+                "<warning>The `<fg=yellow;options=bold>--remove-untracked</>` option "
+                "is deprecated, use the `<fg=yellow;options=bold>--sync</>` option "
+                "instead.</warning>"
             )
 
             with_synchronization = True
@@ -177,7 +182,8 @@ dependencies and not including the current project, run the command with the
             return 0
 
         log_install = (
-            f"<b>Installing</> the current project: <c1>{self.poetry.package.pretty_name}</c1> "
+            f"<b>Installing</> the current project: "
+            f"<c1>{self.poetry.package.pretty_name}</c1> "
             f"(<{{tag}}>{self.poetry.package.pretty_version}</>)"
         )
         overwrite = self._io.output.is_decorated() and not self.io.is_debug()

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -15,14 +15,15 @@ class LockCommand(InstallerCommand):
         option(
             "check",
             None,
-            "Check that the <comment>poetry.lock</> file corresponds to the current version "
-            "of <comment>pyproject.toml</>.",
+            "Check that the <comment>poetry.lock</> file corresponds to the current "
+            "version of <comment>pyproject.toml</>.",
         ),
     ]
 
     help = """
 The <info>lock</info> command reads the <comment>pyproject.toml</> file from the
-current directory, processes it, and locks the dependencies in the <comment>poetry.lock</>
+current directory, processes it, and locks the dependencies in the \
+<comment>poetry.lock</>
 file.
 
 <info>poetry lock</info>

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -29,7 +29,6 @@ class NewCommand(Command):
         from pathlib import Path
 
         from poetry.core.vcs.git import GitConfig
-
         from poetry.layouts import layout
         from poetry.utils.env import SystemEnv
 
@@ -40,7 +39,8 @@ class NewCommand(Command):
 
         path = Path(self.argument("path"))
         if not path.is_absolute():
-            # we do not use resolve here due to compatibility issues for path.resolve(strict=False)
+            # we do not use resolve here due to compatibility issues
+            # for path.resolve(strict=False)
             path = Path.cwd().joinpath(path)
 
         name = self.option("name")
@@ -81,5 +81,6 @@ class NewCommand(Command):
             path = path.relative_to(Path.cwd())
 
         self.line(
-            f"Created package <info>{layout_._package_name}</> in <fg=blue>{path.as_posix()}</>"
+            f"Created package <info>{layout_._package_name}</> "
+            f"in <fg=blue>{path.as_posix()}</>"
         )

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -26,7 +26,8 @@ class PluginAddCommand(InitCommand):
         option(
             "dry-run",
             None,
-            "Output the operations but do not execute anything (implicitly enables --verbose).",
+            "Output the operations but do not execute anything"
+            " (implicitly enables --verbose).",
         )
     ]
 
@@ -35,16 +36,19 @@ The <c1>plugin add</c1> command installs Poetry plugins globally.
 
 It works similarly to the <c1>add</c1> command:
 
-If you do not specify a version constraint, poetry will choose a suitable one based on the available package versions.
+If you do not specify a version constraint,\
+ poetry will choose a suitable one based on the available package versions.
 
 You can specify a package in the following forms:
 
   - A single name (<b>requests</b>)
   - A name and a constraint (<b>requests@^2.23.0</b>)
   - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
-  - A git url with a revision (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+  - A git url with a revision\
+ (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
   - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)
-  - A git SSH url with a revision (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
+  - A git SSH url with a revision\
+ (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
   - A file path (<b>../my-package/my-package.whl</b>)
   - A directory (<b>../my-package/</b>)
   - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)\
@@ -96,7 +100,8 @@ You can specify a package in the following forms:
         # We assume that this environment will be a self contained virtual environment
         # built by the official installer or by pipx.
         # If not, it might lead to side effects since other installed packages
-        # might not be required by Poetry but still taken into account when resolving dependencies.
+        # might not be required by Poetry but still taken into account when
+        # resolving dependencies.
         installed_repository = InstalledRepository.load(
             system_env, with_dependencies=True
         )

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -61,9 +61,9 @@ You can specify a package in the following forms:
 
         from cleo.io.inputs.string_input import StringInput
         from cleo.io.io import IO
+
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.semver.helpers import parse_constraint
-
         from poetry.factory import Factory
         from poetry.packages.project_package import ProjectPackage
         from poetry.repositories.installed_repository import InstalledRepository

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -26,8 +26,8 @@ class PluginAddCommand(InitCommand):
         option(
             "dry-run",
             None,
-            "Output the operations but do not execute anything"
-            " (implicitly enables --verbose).",
+            "Output the operations but do not execute anything "
+            "(implicitly enables --verbose).",
         )
     ]
 
@@ -36,19 +36,19 @@ The <c1>plugin add</c1> command installs Poetry plugins globally.
 
 It works similarly to the <c1>add</c1> command:
 
-If you do not specify a version constraint,\
- poetry will choose a suitable one based on the available package versions.
+If you do not specify a version constraint, \
+poetry will choose a suitable one based on the available package versions.
 
 You can specify a package in the following forms:
 
   - A single name (<b>requests</b>)
   - A name and a constraint (<b>requests@^2.23.0</b>)
   - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
-  - A git url with a revision\
- (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+  - A git url with a revision \
+(<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
   - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)
-  - A git SSH url with a revision\
- (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
+  - A git SSH url with a revision \
+(<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
   - A file path (<b>../my-package/my-package.whl</b>)
   - A directory (<b>../my-package/</b>)
   - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)\

--- a/src/poetry/console/commands/plugin/remove.py
+++ b/src/poetry/console/commands/plugin/remove.py
@@ -24,7 +24,8 @@ class PluginRemoveCommand(Command):
         option(
             "dry-run",
             None,
-            "Output the operations but do not execute anything (implicitly enables --verbose).",
+            "Output the operations but do not execute anything "
+            "(implicitly enables --verbose).",
         )
     ]
 

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -82,7 +82,8 @@ class PluginShowCommand(Command):
                 self.line("      <info>Dependencies</info>")
                 for dependency in package.requires:
                     self.line(
-                        f"        - {dependency.pretty_name} (<c2>{dependency.pretty_constraint}</c2>)"
+                        f"        - {dependency.pretty_name} "
+                        f"(<c2>{dependency.pretty_constraint}</c2>)"
                     )
 
         return 0

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -49,8 +49,8 @@ the config command.
         # Building package first, if told
         if self.option("build"):
             if publisher.files and not self.confirm(
-                f"There are <info>{len(publisher.files)}</info> files ready for publishing. "
-                "Build anyway?"
+                f"There are <info>{len(publisher.files)}</info> files ready "
+                f"for publishing. Build anyway?"
             ):
                 self.line_error("<error>Aborted!</error>")
 

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -15,7 +15,6 @@ from poetry.console.commands.command import Command
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.semver.version import Version
-
     from poetry.repositories.pool import Pool
 
 
@@ -85,10 +84,9 @@ class SelfUpdateCommand(Command):
         return pool
 
     def handle(self) -> int:
+        from poetry.__version__ import __version__
         from poetry.core.packages.dependency import Dependency
         from poetry.core.semver.version import Version
-
-        from poetry.__version__ import __version__
 
         version = self.argument("version")
         if not version:
@@ -167,10 +165,9 @@ class SelfUpdateCommand(Command):
         self._make_bin()
 
     def _update(self, version: "Version") -> None:
+        from poetry.config.config import Config
         from poetry.core.packages.dependency import Dependency
         from poetry.core.packages.project_package import ProjectPackage
-
-        from poetry.config.config import Config
         from poetry.installation.installer import Installer
         from poetry.packages.locker import NullLocker
         from poetry.repositories.installed_repository import InstalledRepository

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -11,9 +11,9 @@ from poetry.console.commands.env_command import EnvCommand
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
+
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
     from poetry.packages.project_package import ProjectPackage
     from poetry.repositories import Repository
     from poetry.repositories.installed_repository import InstalledRepository
@@ -36,7 +36,8 @@ class ShowCommand(EnvCommand):
         option(
             "with",
             None,
-            "Show the information of the specified optional groups' dependencies as well.",
+            "Show the information of the specified optional groups' dependencies "
+            "as well.",
             flag=False,
             multiple=True,
         ),
@@ -46,7 +47,8 @@ class ShowCommand(EnvCommand):
         option(
             "only",
             None,
-            "Only show the information of dependencies belonging to the specified groups.",
+            "Only show the information of dependencies belonging "
+            "to the specified groups.",
             flag=False,
             multiple=True,
         ),
@@ -97,8 +99,9 @@ lists all packages available."""
         only_groups = []
         if self.option("no-dev"):
             self.line(
-                "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is deprecated, "
-                "use the `<fg=yellow;options=bold>--without dev</>` notation instead.</warning>"
+                "<warning>The `<fg=yellow;options=bold>--no-dev</>` option "
+                "is deprecated, use the `<fg=yellow;options=bold>--without dev</>` "
+                "notation instead.</warning>"
             )
             excluded_groups.append("dev")
 
@@ -201,7 +204,8 @@ lists all packages available."""
                 self.line("<info>dependencies</info>")
                 for dependency in pkg.requires:
                     self.line(
-                        f" - <c1>{dependency.pretty_name}</c1> <b>{dependency.pretty_constraint}</b>"
+                        f" - <c1>{dependency.pretty_name}</c1> "
+                        f"<b>{dependency.pretty_constraint}</b>"
                     )
 
             if required_by:
@@ -301,7 +305,10 @@ lists all packages available."""
             ):
                 continue
 
-            line = f"<fg={color}>{name:{name_length - len(install_marker)}}{install_marker}</>"
+            line = (
+                f"<fg={color}>{name:{name_length - len(install_marker)}}"
+                f"{install_marker}</>"
+            )
             if write_version:
                 version = get_package_version_display_string(
                     locked, root=self.poetry.file.parent
@@ -357,7 +364,10 @@ lists all packages available."""
 
             level = 1
             color = self.colors[level]
-            info = f"{tree_bar}── <{color}>{dependency.name}</{color}> {dependency.pretty_constraint}"
+            info = (
+                f"{tree_bar}── <{color}>{dependency.name}</{color}> "
+                f"{dependency.pretty_constraint}"
+            )
             self._write_tree_line(io, info)
 
             tree_bar = tree_bar.replace("└", " ")
@@ -400,7 +410,10 @@ lists all packages available."""
             if dependency.name in current_tree:
                 circular_warn = "(circular dependency aborted here)"
 
-            info = f"{tree_bar}── <{color}>{dependency.name}</{color}> {dependency.pretty_constraint} {circular_warn}"
+            info = (
+                f"{tree_bar}── <{color}>{dependency.name}</{color}> "
+                f"{dependency.pretty_constraint} {circular_warn}"
+            )
             self._write_tree_line(io, info)
 
             tree_bar = tree_bar.replace("└", " ")

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -59,7 +59,8 @@ class SourceAddCommand(Command):
 
         if is_default and is_secondary:
             self.line_error(
-                "Cannot configure a source as both <c1>default</c1> and <c1>secondary</c1>."
+                "Cannot configure a source as both <c1>default</c1> "
+                "and <c1>secondary</c1>."
             )
             return 1
 
@@ -73,18 +74,20 @@ class SourceAddCommand(Command):
         for source in existing_sources:
             if source == new_source:
                 self.line(
-                    f"Source with name <c1>{name}</c1> already exits. Skipping addition."
+                    f"Source with name <c1>{name}</c1> already exists. "
+                    f"Skipping addition."
                 )
                 return 0
             elif source.default and is_default:
                 self.line_error(
-                    f"<error>Source with name <c1>{source.name}</c1> is already set to default. "
+                    f"<error>Source with name <c1>{source.name}</c1> "
+                    f"is already set to default. "
                     f"Only one default source can be configured at a time.</error>"
                 )
                 return 1
 
             if source.name == name:
-                self.line(f"Source with name <c1>{name}</c1> already exits. Updating.")
+                self.line(f"Source with name <c1>{name}</c1> already exists. Updating.")
                 source = new_source
                 new_source = None
 

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -58,7 +58,8 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                 self.line(version.to_string())
             else:
                 self.line(
-                    f"Bumping version from <b>{self.poetry.package.pretty_version}</> to <fg=green>{version}</>"
+                    f"Bumping version from <b>{self.poetry.package.pretty_version}</> "
+                    f"to <fg=green>{version}</>"
                 )
 
             content = self.poetry.file.read()
@@ -71,7 +72,8 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                 self.line(self.poetry.package.pretty_version)
             else:
                 self.line(
-                    f"<comment>{self.poetry.package.name}</> <info>{self.poetry.package.pretty_version}</>"
+                    f"<comment>{self.poetry.package.name}</> "
+                    f"<info>{self.poetry.package.pretty_version}</>"
                 )
 
     def increment_version(self, version: str, rule: str) -> "Version":

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -5,11 +5,11 @@ from typing import List
 from typing import Optional
 
 from cleo.io.null_io import NullIO
-from poetry.core.factory import Factory as BaseFactory
-from poetry.core.toml.file import TOMLFile
 
 from poetry.config.config import Config
 from poetry.config.file_config_source import FileConfigSource
+from poetry.core.factory import Factory as BaseFactory
+from poetry.core.toml.file import TOMLFile
 from poetry.locations import CONFIG_DIR
 from poetry.packages.locker import Locker
 from poetry.packages.project_package import ProjectPackage

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -21,7 +21,6 @@ from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
-
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
 from poetry.utils.setup_reader import SetupReader
@@ -112,7 +111,8 @@ class PackageInfo:
         """
         Helper method to load data from a dictionary produced by `PackageInfo.asdict()`.
 
-        :param data: Data to load. This is expected to be a `dict` object output by `asdict()`.
+        :param data: Data to load. This is expected to be a `dict` object output by
+            `asdict()`.
         """
         cache_version = data.pop("_cache_version", None)
         return cls(cache_version=cache_version, **data)
@@ -129,17 +129,20 @@ class PackageInfo:
         root_dir: Optional[Path] = None,
     ) -> Package:
         """
-        Create a new `poetry.core.packages.package.Package` instance using metadata from this instance.
+        Create a new `poetry.core.packages.package.Package` instance using metadata
+        from this instance.
 
-        :param name: Name to use for the package, if not specified name from this instance is used.
+        :param name: Name to use for the package, if not specified name from this
+            instance is used.
         :param extras: Extras to activate for this package.
-        :param root_dir:  Optional root directory to use for the package. If set, dependency strings
-            will be parsed relative to this directory.
+        :param root_dir:  Optional root directory to use for the package. If set,
+            dependency strings will be parsed relative to this directory.
         """
         name = name or self.name
 
         if not self.version:
-            # The version could not be determined, so we raise an error since it is mandatory.
+            # The version could not be determined, so we raise an error since
+            # it is mandatory.
             raise RuntimeError(f"Unable to retrieve the package version for {name}")
 
         package = Package(
@@ -155,8 +158,8 @@ class PackageInfo:
         package.files = self.files
 
         if root_dir or (self._source_type in {"directory"} and self._source_url):
-            # this is a local poetry project, this means we can extract "richer" requirement information
-            # eg: development requirements etc.
+            # this is a local poetry project, this means we can extract "richer"
+            # requirement information, eg: development requirements etc.
             poetry_package = self._get_poetry_package(path=root_dir or self._source_url)
             if poetry_package:
                 package.extras = poetry_package.extras
@@ -178,8 +181,8 @@ class PackageInfo:
             except ValueError:
                 # Likely unable to parse constraint so we skip it
                 self._log(
-                    f"Invalid constraint ({req}) found in {package.name}-{package.version} dependencies, "
-                    "skipping",
+                    f"Invalid constraint ({req}) found in {package.name}-"
+                    f"{package.version} dependencies, skipping",
                     level="warning",
                 )
                 continue
@@ -188,7 +191,8 @@ class PackageInfo:
                 # this dependency is required by an extra package
                 for extra in dependency.in_extras:
                     if extra not in package.extras:
-                        # this is the first time we encounter this extra for this package
+                        # this is the first time we encounter this extra for
+                        # this package
                         package.extras[extra] = []
 
                     package.extras[extra].append(dependency)
@@ -206,7 +210,8 @@ class PackageInfo:
         cls, dist: Union[pkginfo.BDist, pkginfo.SDist, pkginfo.Wheel]
     ) -> "PackageInfo":
         """
-        Helper method to parse package information from a `pkginfo.Distribution` instance.
+        Helper method to parse package information from a `pkginfo.Distribution`
+        instance.
 
         :param dist: The distribution instance to parse information from.
         """
@@ -237,9 +242,9 @@ class PackageInfo:
     @classmethod
     def _from_sdist_file(cls, path: Path) -> "PackageInfo":
         """
-        Helper method to parse package information from an sdist file. We attempt to first inspect the
-        file using `pkginfo.SDist`. If this does not provide us with package requirements, we extract the
-        source and handle it as a directory.
+        Helper method to parse package information from an sdist file. We attempt to
+        first inspect the file using `pkginfo.SDist`. If this does not provide us with
+        package requirements, we extract the source and handle it as a directory.
 
         :param path: The sdist file to parse information from.
         """
@@ -302,9 +307,10 @@ class PackageInfo:
     @classmethod
     def from_setup_files(cls, path: Path) -> "PackageInfo":
         """
-        Mechanism to parse package information from a `setup.[py|cfg]` file. This uses the implementation
-        at `poetry.utils.setup_reader.SetupReader` in order to parse the file. This is not reliable for
-        complex setup files and should only attempted as a fallback.
+        Mechanism to parse package information from a `setup.[py|cfg]` file. This uses
+        the implementation at `poetry.utils.setup_reader.SetupReader` in order to parse
+        the file. This is not reliable for complex setup files and should only attempted
+        as a fallback.
 
         :param path: Path to `setup.py` file
         """
@@ -361,9 +367,9 @@ class PackageInfo:
         :param path: Path to search.
         """
         pattern = "**/*.*-info"
-        # Sometimes pathlib will fail on recursive symbolic links, so we need to workaround it
-        # and use the glob module instead. Note that this does not happen with pathlib2
-        # so it's safe to use it for Python < 3.4.
+        # Sometimes pathlib will fail on recursive symbolic links, so we need to work
+        # around it and use the glob module instead. Note that this does not happen with
+        # pathlib2 so it's safe to use it for Python < 3.4.
         directories = glob.iglob(path.joinpath(pattern).as_posix(), recursive=True)
 
         for d in directories:
@@ -508,13 +514,14 @@ class PackageInfo:
     @classmethod
     def from_directory(cls, path: Path, disable_build: bool = False) -> "PackageInfo":
         """
-        Generate package information from a package source directory. If `disable_build` is not `True` and
-        introspection of all available metadata fails, the package is attempted to be build in an isolated
-        environment so as to generate required metadata.
+        Generate package information from a package source directory. If `disable_build`
+        is not `True` and introspection of all available metadata fails, the package is
+        attempted to be built in an isolated environment so as to generate required
+        metadata.
 
         :param path: Path to generate package information from.
-        :param disable_build: If not `True` and setup reader fails, PEP 517 isolated build is attempted in
-            order to gather metadata.
+        :param disable_build: If not `True` and setup reader fails, PEP 517 isolated
+            build is attempted in order to gather metadata.
         """
         project_package = cls._get_poetry_package(path)
         if project_package:

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -7,7 +7,6 @@ from typing import List
 from typing import Optional
 
 from poetry.core.packages.utils.link import Link
-
 from poetry.installation.chooser import InvalidWheelName
 from poetry.installation.chooser import Wheel
 

--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -13,7 +13,6 @@ from poetry.utils.patterns import wheel_file_re
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.utils.link import Link
-
     from poetry.repositories.pool import Pool
     from poetry.utils.env import Env
 
@@ -112,7 +111,8 @@ class Chooser:
 
         if links and not selected_links:
             raise RuntimeError(
-                f"Retrieved digest for link {link.filename}({h}) not in poetry.lock metadata {hashes}"
+                f"Retrieved digest for link {link.filename}({h}) "
+                f"not in poetry.lock metadata {hashes}"
             )
 
         return selected_links

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -16,11 +16,11 @@ from typing import Optional
 from typing import Union
 
 from cleo.io.null_io import NullIO
+
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.pyproject.toml import PyProjectTOML
-
 from poetry.installation.chef import Chef
 from poetry.installation.chooser import Chooser
 from poetry.utils._compat import decode
@@ -34,9 +34,9 @@ from poetry.utils.pip import pip_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-    from poetry.core.packages.package import Package
 
     from poetry.config.config import Config
+    from poetry.core.packages.package import Package
     from poetry.installation.operations import OperationTypes
     from poetry.installation.operations.install import Install
     from poetry.installation.operations.operation import Operation
@@ -230,7 +230,8 @@ class Executor:
                     with self._lock:
                         self._sections[id(operation)] = self._io.section()
                         self._sections[id(operation)].write_line(
-                            f"  <fg=blue;options=bold>•</> {op_message}: <fg=blue>Pending...</>"
+                            f"  <fg=blue;options=bold>•</> "
+                            f"{op_message}: <fg=blue>Pending...</>"
                         )
             else:
                 if self._should_write_operation(operation):
@@ -266,7 +267,11 @@ class Executor:
                 if not self.supports_fancy_output():
                     io = self._io
                 else:
-                    message = f"  <error>•</error> {self.get_operation_message(operation, error=True)}: <error>Failed</error>"
+                    message = (
+                        f"  <error>•</error> "
+                        f"{self.get_operation_message(operation, error=True)}: "
+                        f"<error>Failed</error>"
+                    )
                     self._write(operation, message)
                     io = self._sections.get(id(operation), self._io)
 
@@ -279,7 +284,11 @@ class Executor:
                     self._shutdown = True
         except KeyboardInterrupt:
             try:
-                message = f"  <warning>•</warning> {self.get_operation_message(operation, warning=True)}: <warning>Cancelled</warning>"
+                message = (
+                    f"  <warning>•</warning> "
+                    f"{self.get_operation_message(operation, warning=True)}: "
+                    f"<warning>Cancelled</warning>"
+                )
                 if not self.supports_fancy_output():
                     self._io.write_line(message)
                 else:
@@ -376,21 +385,26 @@ class Executor:
 
         if operation.job_type == "install":
             return (
-                f"<{base_tag}>Installing <{package_color}>{operation.package.name}</{package_color}> "
+                f"<{base_tag}>Installing "
+                f"<{package_color}>{operation.package.name}</{package_color}> "
                 f"(<{operation_color}>{operation.package.full_pretty_version}</>)</>"
             )
 
         if operation.job_type == "uninstall":
             return (
-                f"<{base_tag}>Removing <{package_color}>{operation.package.name}</{package_color}> "
+                f"<{base_tag}>Removing "
+                f"<{package_color}>{operation.package.name}</{package_color}> "
                 f"(<{operation_color}>{operation.package.full_pretty_version}</>)</>"
             )
 
         if operation.job_type == "update":
             return (
-                f"<{base_tag}>Updating <{package_color}>{operation.initial_package.name}</{package_color}> "
-                f"(<{source_operation_color}>{operation.initial_package.full_pretty_version}</{source_operation_color}> "
-                f"-> <{operation_color}>{operation.target_package.full_pretty_version}</>)</>"
+                f"<{base_tag}>Updating "
+                f"<{package_color}>{operation.initial_package.name}</{package_color}> "
+                f"(<{source_operation_color}>"
+                f"{operation.initial_package.full_pretty_version}"
+                f"</{source_operation_color}> -> <{operation_color}>"
+                f"{operation.target_package.full_pretty_version}</>)</>"
             )
         return ""
 
@@ -464,7 +478,10 @@ class Executor:
             archive = self._download(operation)
 
         operation_message = self.get_operation_message(operation)
-        message = f"  <fg=blue;options=bold>•</> {operation_message}: <info>Installing...</info>"
+        message = (
+            f"  <fg=blue;options=bold>•</> {operation_message}: "
+            f"<info>Installing...</info>"
+        )
         self._write(operation, message)
         return self.pip_install(archive, upgrade=operation.job_type == "update")
 
@@ -492,7 +509,10 @@ class Executor:
         package = operation.package
         operation_message = self.get_operation_message(operation)
 
-        message = f"  <fg=blue;options=bold>•</> {operation_message}: <info>Preparing...</info>"
+        message = (
+            f"  <fg=blue;options=bold>•</> {operation_message}: "
+            f"<info>Preparing...</info>"
+        )
         self._write(operation, message)
 
         archive = Path(package.source_url)
@@ -509,7 +529,10 @@ class Executor:
         package = operation.package
         operation_message = self.get_operation_message(operation)
 
-        message = f"  <fg=blue;options=bold>•</> {operation_message}: <info>Building...</info>"
+        message = (
+            f"  <fg=blue;options=bold>•</> {operation_message}: "
+            f"<info>Building...</info>"
+        )
         self._write(operation, message)
 
         if package.root_dir:
@@ -644,7 +667,8 @@ class Executor:
 
         if archive_hash not in known_hashes:
             raise RuntimeError(
-                f"Hash for {package} from archive {archive_path.name} not found in known hashes (was: {archive_hash})"
+                f"Hash for {package} from archive {archive_path.name} not found "
+                f"in known hashes (was: {archive_hash})"
             )
 
         return archive_hash

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -22,9 +22,9 @@ from poetry.utils.helpers import pluralize
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-    from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config
+    from poetry.core.packages.project_package import ProjectPackage
     from poetry.installation.base_installer import BaseInstaller
     from poetry.installation.operations import OperationTypes
     from poetry.installation.operations.operation import Operation
@@ -414,14 +414,16 @@ class Installer:
         if operation.skipped:
             if self.is_verbose() and (self._execute_operations or self.is_dry_run()):
                 self._io.write_line(
-                    f"  - Skipping <c1>{target.pretty_name}</c1> (<c2>{target.full_pretty_version}</c2>) {operation.skip_reason}"
+                    f"  - Skipping <c1>{target.pretty_name}</c1> "
+                    f"(<c2>{target.full_pretty_version}</c2>) {operation.skip_reason}"
                 )
 
             return
 
         if self._execute_operations or self.is_dry_run():
             self._io.write_line(
-                f"  - Installing <c1>{target.pretty_name}</c1> (<c2>{target.full_pretty_version}</c2>)"
+                f"  - Installing <c1>{target.pretty_name}</c1> "
+                f"(<c2>{target.full_pretty_version}</c2>)"
             )
 
         if not self._execute_operations:
@@ -445,7 +447,8 @@ class Installer:
         if self._execute_operations or self.is_dry_run():
             self._io.write_line(
                 f"  - Updating <c1>{target.pretty_name}</c1> "
-                f"(<c2>{source.full_pretty_version}</c2> -> <c2>{target.full_pretty_version}</c2>)"
+                f"(<c2>{source.full_pretty_version}</c2> -> "
+                f"<c2>{target.full_pretty_version}</c2>)"
             )
 
         if not self._execute_operations:
@@ -458,14 +461,16 @@ class Installer:
         if operation.skipped:
             if self.is_verbose() and (self._execute_operations or self.is_dry_run()):
                 self._io.write_line(
-                    f"  - Not removing <c1>{target.pretty_name}</c1> (<c2>{target.pretty_version}</c2>) {operation.skip_reason}"
+                    f"  - Not removing <c1>{target.pretty_name}</c1> "
+                    f"(<c2>{target.pretty_version}</c2>) {operation.skip_reason}"
                 )
 
             return
 
         if self._execute_operations or self.is_dry_run():
             self._io.write_line(
-                f"  - Removing <c1>{target.pretty_name}</c1> (<c2>{target.pretty_version}</c2>)"
+                f"  - Removing <c1>{target.pretty_name}</c1> "
+                f"(<c2>{target.pretty_version}</c2>)"
             )
 
         if not self._execute_operations:

--- a/src/poetry/installation/operations/install.py
+++ b/src/poetry/installation/operations/install.py
@@ -25,7 +25,13 @@ class Install(Operation):
         return "install"
 
     def __str__(self) -> str:
-        return f"Installing {self.package.pretty_name} ({self.format_version(self.package)})"
+        return (
+            f"Installing {self.package.pretty_name} "
+            f"({self.format_version(self.package)})"
+        )
 
     def __repr__(self) -> str:
-        return f"<Install {self.package.pretty_name} ({self.format_version(self.package)})>"
+        return (
+            f"<Install {self.package.pretty_name} "
+            f"({self.format_version(self.package)})>"
+        )

--- a/src/poetry/installation/operations/uninstall.py
+++ b/src/poetry/installation/operations/uninstall.py
@@ -28,7 +28,13 @@ class Uninstall(Operation):
         return "uninstall"
 
     def __str__(self) -> str:
-        return f"Uninstalling {self.package.pretty_name} ({self.format_version(self._package)})"
+        return (
+            f"Uninstalling {self.package.pretty_name} "
+            f"({self.format_version(self._package)})"
+        )
 
     def __repr__(self) -> str:
-        return f"<Uninstall {self.package.pretty_name} ({self.format_version(self.package)})>"
+        return (
+            f"<Uninstall {self.package.pretty_name} "
+            f"({self.format_version(self.package)})>"
+        )

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -9,7 +9,6 @@ from typing import Any
 from typing import Union
 
 from poetry.core.pyproject.toml import PyProjectTOML
-
 from poetry.installation.base_installer import BaseInstaller
 from poetry.utils._compat import encode
 from poetry.utils.helpers import safe_rmtree
@@ -19,8 +18,8 @@ from poetry.utils.pip import pip_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-    from poetry.core.packages.package import Package
 
+    from poetry.core.packages.package import Package
     from poetry.repositories.pool import Pool
     from poetry.utils.env import Env
 
@@ -52,7 +51,8 @@ class PipInstaller(BaseInstaller):
             parsed = urllib.parse.urlparse(package.source_url)
             if parsed.scheme == "http":
                 self._io.write_error(
-                    f"    <warning>Installing from unsecure host: {parsed.hostname}</warning>"
+                    f"    <warning>Installing from unsecure host: "
+                    f"{parsed.hostname}</warning>"
                 )
                 args += ["--trusted-host", parsed.hostname]
 
@@ -159,7 +159,10 @@ class PipInstaller(BaseInstaller):
             return req
 
         if package.source_type == "git":
-            req = f"git+{package.source_url}@{package.source_reference}#egg={package.name}"
+            req = (
+                f"git+{package.source_url}@{package.source_reference}"
+                f"#egg={package.name}"
+            )
 
             if package.develop:
                 req = ["-e", req]

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -13,8 +13,9 @@ from poetry.utils.helpers import module_name
 
 
 if TYPE_CHECKING:
-    from poetry.core.pyproject.toml import PyProjectTOML
     from tomlkit.items import InlineTable
+
+    from poetry.core.pyproject.toml import PyProjectTOML
 
 
 POETRY_DEFAULT = """\
@@ -63,7 +64,8 @@ class Layout:
         if self._readme_format not in self.ACCEPTED_README_FORMATS:
             accepted_readme_formats = ", ".join(self.ACCEPTED_README_FORMATS)
             raise ValueError(
-                f"Invalid readme format '{readme_format}', use one of {accepted_readme_formats}."
+                f"Invalid readme format '{readme_format}', "
+                f"use one of {accepted_readme_formats}."
             )
 
         self._license = license

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -11,7 +11,6 @@ from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.semver.version import Version
-
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
 from poetry.utils.helpers import is_dir_writable
@@ -20,8 +19,8 @@ from poetry.utils.pip import pip_editable_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-    from poetry.core.poetry import Poetry
 
+    from poetry.core.poetry import Poetry
     from poetry.utils.env import Env
 
 SCRIPT_TEMPLATE = """\
@@ -47,7 +46,8 @@ class EditableBuilder(Builder):
 
     def build(self) -> None:
         self._debug(
-            f"  - Building package <c1>{self._package.name}</c1> in <info>editable</info> mode"
+            f"  - Building package <c1>{self._package.name}</c1> "
+            f"in <info>editable</info> mode"
         )
 
         if self._package.build_script:
@@ -63,7 +63,8 @@ class EditableBuilder(Builder):
             distribution_name=self._package.name
         ):
             self._debug(
-                f"  - Removed <c2>{removed.name}</c2> directory from <b>{removed.parent}</b>"
+                f"  - Removed <c2>{removed.name}</c2> directory "
+                f"from <b>{removed.parent}</b>"
             )
 
         added_files = []
@@ -121,7 +122,8 @@ class EditableBuilder(Builder):
         # remove any pre-existing pth files for this package
         for file in self._env.site_packages.find(path=pth_file, writable_only=True):
             self._debug(
-                f"  - Removing existing <c2>{file.name}</c2> from <b>{file.parent}</b> for {self._poetry.file.parent}"
+                f"  - Removing existing <c2>{file.name}</c2> from <b>{file.parent}</b> "
+                f"for {self._poetry.file.parent}"
             )
             # We can't use unlink(missing_ok=True) because it's not always available
             if file.exists():
@@ -132,13 +134,15 @@ class EditableBuilder(Builder):
                 pth_file, content, encoding="utf-8"
             )
             self._debug(
-                f"  - Adding <c2>{pth_file.name}</c2> to <b>{pth_file.parent}</b> for {self._poetry.file.parent}"
+                f"  - Adding <c2>{pth_file.name}</c2> to <b>{pth_file.parent}</b> "
+                f"for {self._poetry.file.parent}"
             )
             return [pth_file]
         except OSError:
             # TODO: Replace with PermissionError
             self._io.write_error_line(
-                f"  - Failed to create <c2>{pth_file.name}</c2> for {self._poetry.file.parent}"
+                f"  - Failed to create <c2>{pth_file.name}</c2> "
+                f"for {self._poetry.file.parent}"
             )
             return []
 
@@ -151,7 +155,8 @@ class EditableBuilder(Builder):
                 break
         else:
             self._io.write_error_line(
-                f"  - Failed to find a suitable script installation directory for {self._poetry.file.parent}"
+                f"  - Failed to find a suitable script installation directory "
+                f"for {self._poetry.file.parent}"
             )
             return []
 
@@ -185,7 +190,8 @@ class EditableBuilder(Builder):
                 cmd_script = script_file.with_suffix(".cmd")
                 cmd = WINDOWS_CMD_TEMPLATE.format(python=self._env.python, script=name)
                 self._debug(
-                    f"  - Adding the <c2>{cmd_script.name}</c2> script wrapper to <b>{scripts_path}</b>"
+                    f"  - Adding the <c2>{cmd_script.name}</c2> script wrapper "
+                    f"to <b>{scripts_path}</b>"
                 )
 
                 with cmd_script.open("w", encoding="utf-8") as f:
@@ -204,7 +210,8 @@ class EditableBuilder(Builder):
         dist_info = self._env.site_packages.mkdir(Path(builder.dist_info))
 
         self._debug(
-            f"  - Adding the <c2>{dist_info.name}</c2> directory to <b>{dist_info.parent}</b>"
+            f"  - Adding the <c2>{dist_info.name}</c2> directory "
+            f"to <b>{dist_info.parent}</b>"
         )
 
         with dist_info.joinpath("METADATA").open("w", encoding="utf-8") as f:

--- a/src/poetry/mixology/__init__.py
+++ b/src/poetry/mixology/__init__.py
@@ -7,7 +7,6 @@ from poetry.mixology.version_solver import VersionSolver
 
 if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
-
     from poetry.mixology.result import SolverResult
     from poetry.packages import DependencyPackage
     from poetry.puzzle.provider import Provider

--- a/src/poetry/mixology/assignment.py
+++ b/src/poetry/mixology/assignment.py
@@ -8,7 +8,6 @@ from poetry.mixology.term import Term
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
     from poetry.mixology.incompatibility import Incompatibility
 
 

--- a/src/poetry/mixology/failure.py
+++ b/src/poetry/mixology/failure.py
@@ -42,10 +42,10 @@ class _Writer:
             if isinstance(incompatibility.cause, PythonCause):
                 if not required_python_version_notification:
                     buffer.append(
-                        "The current project's Python requirement "
+                        f"The current project's Python requirement "
                         f"({incompatibility.cause.root_python_version}) "
-                        "is not compatible with some of the required "
-                        "packages Python requirement:"
+                        f"is not compatible with some of the required "
+                        f"packages Python requirement:"
                     )
                     required_python_version_notification = True
 

--- a/src/poetry/mixology/failure.py
+++ b/src/poetry/mixology/failure.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import Tuple
 
 from poetry.core.semver.helpers import parse_constraint
-
 from poetry.mixology.incompatibility_cause import ConflictCause
 from poetry.mixology.incompatibility_cause import PythonCause
 
@@ -43,7 +42,8 @@ class _Writer:
             if isinstance(incompatibility.cause, PythonCause):
                 if not required_python_version_notification:
                     buffer.append(
-                        f"The current project's Python requirement ({incompatibility.cause.root_python_version}) "
+                        "The current project's Python requirement "
+                        f"({incompatibility.cause.root_python_version}) "
                         "is not compatible with some of the required "
                         "packages Python requirement:"
                     )
@@ -55,8 +55,8 @@ class _Writer:
                 constraint = parse_constraint(incompatibility.cause.python_version)
                 buffer.append(
                     f"  - {incompatibility.terms[0].dependency.name} requires Python "
-                    f"{incompatibility.cause.python_version}, so it will not be satisfied "
-                    f"for Python {root_constraint.difference(constraint)}"
+                    f"{incompatibility.cause.python_version}, so it will not be "
+                    f"satisfied for Python {root_constraint.difference(constraint)}"
                 )
 
         if required_python_version_notification:
@@ -145,7 +145,8 @@ class _Writer:
                 self._visit(without_line, details_for_cause)
                 self._write(
                     incompatibility,
-                    f"{conjunction} because {with_line!s} ({line}), {incompatibility_string}.",
+                    f"{conjunction} because {with_line!s} ({line}), "
+                    f"{incompatibility_string}.",
                     numbered=numbered,
                 )
             else:
@@ -170,7 +171,9 @@ class _Writer:
 
                     self._write(
                         incompatibility,
-                        f"{conjunction} because {cause.conflict!s} ({self._line_numbers[cause.conflict]}), {incompatibility_string}",
+                        f"{conjunction} because {cause.conflict!s} "
+                        f"({self._line_numbers[cause.conflict]}), "
+                        f"{incompatibility_string}",
                         numbered=numbered,
                     )
         elif isinstance(cause.conflict.cause, ConflictCause) or isinstance(

--- a/src/poetry/mixology/incompatibility.py
+++ b/src/poetry/mixology/incompatibility.py
@@ -54,11 +54,11 @@ class Incompatibility:
                 if ref in by_ref:
                     by_ref[ref] = by_ref[ref].intersect(term)
 
-                    # If we have two terms that refer to the same package but have a null
-                    # intersection, they're mutually exclusive, making this incompatibility
-                    # irrelevant, since we already know that mutually exclusive version
-                    # ranges are incompatible. We should never derive an irrelevant
-                    # incompatibility.
+                    # If we have two terms that refer to the same package but have a
+                    # null intersection, they're mutually exclusive, making this
+                    # incompatibility irrelevant, since we already know that mutually
+                    # exclusive version ranges are incompatible. We should never derive
+                    # an irrelevant incompatibility.
                     assert by_ref[ref] is not None
                 else:
                     by_ref[ref] = term
@@ -127,7 +127,10 @@ class Incompatibility:
             assert depender.is_positive()
             assert not dependee.is_positive()
 
-            return f"{self._terse(depender, allow_every=True)} depends on {self._terse(dependee)}"
+            return (
+                f"{self._terse(depender, allow_every=True)} "
+                f"depends on {self._terse(dependee)}"
+            )
         elif isinstance(self._cause, PythonCause):
             assert len(self._terms) == 1
             assert self._terms[0].is_positive()
@@ -150,7 +153,10 @@ class Incompatibility:
             assert len(self._terms) == 1
             assert self._terms[0].is_positive()
 
-            return f"no versions of {self._terms[0].dependency.name} match {self._terms[0].constraint}"
+            return (
+                f"no versions of {self._terms[0].dependency.name} "
+                f"match {self._terms[0].constraint}"
+            )
         elif isinstance(self._cause, PackageNotFoundCause):
             assert len(self._terms) == 1
             assert self._terms[0].is_positive()
@@ -161,7 +167,10 @@ class Incompatibility:
             assert not self._terms[0].is_positive()
             assert self._terms[0].dependency.is_root
 
-            return f"{self._terms[0].dependency.name} is {self._terms[0].dependency.constraint}"
+            return (
+                f"{self._terms[0].dependency.name} is "
+                f"{self._terms[0].dependency.constraint}"
+            )
         elif self.is_failure():
             return "version solving failed"
 
@@ -205,7 +214,10 @@ class Incompatibility:
                 return f"if {' and '.join(positive)} then {' or '.join(negative)}"
 
             positive_term = [term for term in self._terms if term.is_positive()][0]
-            return f"{self._terse(positive_term, allow_every=True)} requires {' or '.join(negative)}"
+            return (
+                f"{self._terse(positive_term, allow_every=True)} "
+                f"requires {' or '.join(negative)}"
+            )
         elif positive:
             return f"one of {' or '.join(positive)} must be false"
         else:

--- a/src/poetry/mixology/partial_solution.py
+++ b/src/poetry/mixology/partial_solution.py
@@ -9,7 +9,6 @@ from poetry.mixology.set_relation import SetRelation
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
     from poetry.mixology.incompatibility import Incompatibility
     from poetry.mixology.term import Term
 
@@ -20,7 +19,8 @@ class PartialSolution:
     # what's true for the eventual set of package versions that will comprise the
     # total solution.
     #
-    # See https://github.com/dart-lang/mixology/tree/master/doc/solver.md#partial-solution.
+    # See
+    # https://github.com/dart-lang/mixology/tree/master/doc/solver.md#partial-solution.
     """
 
     def __init__(self) -> None:

--- a/src/poetry/mixology/solutions/solutions/python_requirement_solution.py
+++ b/src/poetry/mixology/solutions/solutions/python_requirement_solution.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 class PythonRequirementSolution(Solution):
     def __init__(self, exception: "PackageNotFoundCause") -> None:
         from poetry.core.semver.helpers import parse_constraint
-
         from poetry.mixology.incompatibility_cause import PythonCause
 
         self._title = "Check your dependencies Python requirement."
@@ -26,13 +25,16 @@ class PythonRequirementSolution(Solution):
                 constraint = parse_constraint(incompatibility.cause.python_version)
 
                 version_solutions.append(
-                    f"For <fg=default;options=bold>{incompatibility.terms[0].dependency.name}</>, "
-                    "a possible solution would be to set the `<fg=default;options=bold>python</>` "
-                    f'property to <fg=yellow>"{root_constraint.intersect(constraint)}"</>'
+                    f"For <fg=default;options=bold>"
+                    f"{incompatibility.terms[0].dependency.name}</>, "
+                    f"a possible solution would be to set the "
+                    f"`<fg=default;options=bold>python</>` property to "
+                    f'<fg=yellow>"{root_constraint.intersect(constraint)}"</>'
                 )
 
         description = (
-            "The Python requirement can be specified via the `<fg=default;options=bold>python</>` "
+            "The Python requirement can be specified via the "
+            "`<fg=default;options=bold>python</>` "
             "or `<fg=default;options=bold>markers</>` properties"
         )
         if version_solutions:
@@ -53,6 +55,8 @@ class PythonRequirementSolution(Solution):
     @property
     def documentation_links(self) -> List[str]:
         return [
-            "https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies",
-            "https://python-poetry.org/docs/dependency-specification/#using-environment-markers",
+            "https://python-poetry.org/docs/dependency-specification/"
+            "#python-restricted-dependencies",
+            "https://python-poetry.org/docs/dependency-specification/"
+            "#using-environment-markers",
         ]

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -297,8 +297,8 @@ class VersionSolver:
 
             partially = "" if difference is None else " partially"
             self._log(
-                f"! {most_recent_term} is{partially} satisfied"
-                f" by {most_recent_satisfier}"
+                f"! {most_recent_term} is{partially} satisfied "
+                f"by {most_recent_satisfier}"
             )
             self._log(f'! which is caused by "{most_recent_satisfier.cause}"')
             self._log(f"! thus: {incompatibility}")

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -8,7 +8,6 @@ from typing import Tuple
 from typing import Union
 
 from poetry.core.packages.dependency import Dependency
-
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import ConflictCause
@@ -24,7 +23,6 @@ from poetry.mixology.term import Term
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.project_package import ProjectPackage
-
     from poetry.puzzle.provider import Provider
 
 
@@ -109,8 +107,8 @@ class VersionSolver:
 
                 if result is _conflict:
                     # If the incompatibility is satisfied by the solution, we use
-                    # _resolve_conflict() to determine the root cause of the conflict as a
-                    # new incompatibility.
+                    # _resolve_conflict() to determine the root cause of the conflict
+                    # as a new incompatibility.
                     #
                     # It also backjumps to a point in the solution
                     # where that incompatibility will allow us to derive new assignments
@@ -180,13 +178,14 @@ class VersionSolver:
     def _resolve_conflict(self, incompatibility: Incompatibility) -> Incompatibility:
         """
         Given an incompatibility that's satisfied by _solution,
-        The `conflict resolution`_ constructs a new incompatibility that encapsulates the root
-        cause of the conflict and backtracks _solution until the new
+        The `conflict resolution`_ constructs a new incompatibility that encapsulates
+        the root cause of the conflict and backtracks _solution until the new
         incompatibility will allow _propagate() to deduce new assignments.
 
         Adds the new incompatibility to _incompatibilities and returns it.
 
-        .. _conflict resolution: https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
+        .. _conflict resolution:
+        https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
         """
         self._log(f"conflict: {incompatibility}")
 
@@ -286,7 +285,8 @@ class VersionSolver:
             # the incompatibility as well, See the `algorithm documentation`_ for
             # details.
             #
-            # .. _algorithm documentation: https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
+            # .. _algorithm documentation:
+            # https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution  # noqa: E501
             if difference is not None:
                 new_terms.append(difference.inverse)
 
@@ -297,7 +297,8 @@ class VersionSolver:
 
             partially = "" if difference is None else " partially"
             self._log(
-                f"! {most_recent_term} is{partially} satisfied by {most_recent_satisfier}"
+                f"! {most_recent_term} is{partially} satisfied"
+                f" by {most_recent_satisfier}"
             )
             self._log(f'! which is caused by "{most_recent_satisfier.cause}"')
             self._log(f"! thus: {incompatibility}")

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -17,13 +17,6 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
-from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.package import Package
-from poetry.core.semver.helpers import parse_constraint
-from poetry.core.semver.version import Version
-from poetry.core.toml.file import TOMLFile
-from poetry.core.version.markers import parse_marker
-from poetry.core.version.requirements import InvalidRequirement
 from tomlkit import array
 from tomlkit import document
 from tomlkit import inline_table
@@ -31,6 +24,13 @@ from tomlkit import item
 from tomlkit import table
 from tomlkit.exceptions import TOMLKitError
 
+from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.package import Package
+from poetry.core.semver.helpers import parse_constraint
+from poetry.core.semver.version import Version
+from poetry.core.toml.file import TOMLFile
+from poetry.core.version.markers import parse_marker
+from poetry.core.version.requirements import InvalidRequirement
 from poetry.packages import DependencyPackage
 from poetry.utils.extras import get_extra_package_names
 
@@ -179,7 +179,8 @@ class Locker:
 
                 root_dir = self._lock.path.parent
                 if package.source_type == "directory":
-                    # root dir should be the source of the package relative to the lock path
+                    # root dir should be the source of the package relative
+                    # to the lock path
                     root_dir = Path(package.source_url)
 
                 if isinstance(constraint, list):
@@ -290,7 +291,8 @@ class Locker:
         pinned_versions: bool = False,
         with_nested: bool = False,
     ) -> Iterable[Dependency]:
-        # group packages entries by name, this is required because requirement might use different constraints
+        # group packages entries by name, this is required because requirement might
+        # use different constraints
         packages_by_name = {}
         for pkg in locked_packages:
             if pkg.name not in packages_by_name:
@@ -482,9 +484,11 @@ class Locker:
         lock_version_allowed = accepted_versions.allows(lock_version)
         if lock_version_allowed and current_version < lock_version:
             logger.warning(
-                "The lock file might not be compatible with the current version of Poetry.\n"
-                "Upgrade Poetry to ensure the lock file is read properly or, alternatively, "
-                "regenerate the lock file with the `poetry lock` command."
+                "The lock file might not be compatible with "
+                "the current version of Poetry.\n"
+                "Upgrade Poetry to ensure the lock file is read properly or, "
+                "alternatively, regenerate the lock file with the `poetry lock` "
+                "command."
             )
         elif not lock_version_allowed:
             raise RuntimeError(

--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -2,18 +2,16 @@ from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
 
-from poetry.core.poetry import Poetry as BasePoetry
-
 from poetry.__version__ import __version__
 from poetry.config.source import Source
+from poetry.core.poetry import Poetry as BasePoetry
 
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from poetry.core.packages.project_package import ProjectPackage
-
     from poetry.config.config import Config
+    from poetry.core.packages.project_package import ProjectPackage
     from poetry.packages.locker import Locker
     from poetry.plugins.plugin_manager import PluginManager
     from poetry.repositories.pool import Pool

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -89,7 +89,8 @@ class Publisher:
         if repository_name == "pypi":
             repository_name = "PyPI"
         self._io.write_line(
-            f"Publishing <c1>{self._package.pretty_name}</c1> (<c2>{self._package.pretty_version}</c2>) "
+            f"Publishing <c1>{self._package.pretty_name}</c1> "
+            f"(<c2>{self._package.pretty_version}</c2>) "
             f"to <info>{repository_name}</info>"
         )
 

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -11,10 +11,6 @@ from typing import Union
 
 import requests
 
-from poetry.core.masonry.metadata import Metadata
-from poetry.core.masonry.utils.helpers import escape_name
-from poetry.core.masonry.utils.helpers import escape_version
-from poetry.core.utils.helpers import normalize_version
 from requests import adapters
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -24,6 +20,10 @@ from requests_toolbelt.multipart import MultipartEncoder
 from requests_toolbelt.multipart import MultipartEncoderMonitor
 
 from poetry.__version__ import __version__
+from poetry.core.masonry.metadata import Metadata
+from poetry.core.masonry.utils.helpers import escape_name
+from poetry.core.masonry.utils.helpers import escape_version
+from poetry.core.utils.helpers import normalize_version
 from poetry.utils.patterns import wheel_file_re
 
 
@@ -83,7 +83,8 @@ class Uploader:
 
         wheels = list(
             dist.glob(
-                f"{escape_name(self._package.pretty_name)}-{escape_version(version)}-*.whl"
+                f"{escape_name(self._package.pretty_name)}-{escape_version(version)}"
+                "-*.whl"
             )
         )
         tars = list(dist.glob(f"{self._package.pretty_name}-{version}.tar.gz"))
@@ -293,9 +294,9 @@ class Uploader:
         Register a package to a repository.
         """
         dist = self._poetry.file.parent / "dist"
-        file = (
-            dist
-            / f"{self._package.name}-{normalize_version(self._package.version.text)}.tar.gz"
+        file = dist / (
+            f"{self._package.name}-{normalize_version(self._package.version.text)}"
+            ".tar.gz"
         )
 
         if not file.exists():

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -18,11 +18,11 @@ from typing import Set
 from typing import Union
 
 from cleo.ui.progress_indicator import ProgressIndicator
+
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
 from poetry.core.semver.version import Version
 from poetry.core.vcs.git import Git
 from poetry.core.version.markers import MarkerUnion
-
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
 from poetry.mixology.incompatibility import Incompatibility
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
-
     from poetry.repositories import Pool
     from poetry.utils.env import Env
 
@@ -258,7 +257,8 @@ class Provider:
         if dependency.name != package.name:
             # For now, the dependency's name must match the actual package's name
             raise RuntimeError(
-                f"The dependency name for {dependency.name} does not match the actual package's name: {package.name}"
+                f"The dependency name for {dependency.name} does not match "
+                f"the actual package's name: {package.name}"
             )
 
         if dependency.base is not None:
@@ -318,7 +318,8 @@ class Provider:
         if name and name != package.name:
             # For now, the dependency's name must match the actual package's name
             raise RuntimeError(
-                f"The dependency name for {name} does not match the actual package's name: {package.name}"
+                f"The dependency name for {name} does not match "
+                f"the actual package's name: {package.name}"
             )
 
         return package
@@ -332,7 +333,8 @@ class Provider:
         if dependency.name != package.name:
             # For now, the dependency's name must match the actual package's name
             raise RuntimeError(
-                f"The dependency name for {dependency.name} does not match the actual package's name: {package.name}"
+                f"The dependency name for {dependency.name} does not match "
+                f"the actual package's name: {package.name}"
             )
 
         for extra in dependency.extras:
@@ -631,8 +633,8 @@ class Provider:
             def fmt_warning(d: "Dependency") -> str:
                 marker = d.marker if not d.marker.is_any() else "*"
                 return (
-                    f"<c1>{d.name}</c1> <fg=default>(<c2>{d.pretty_constraint}</c2>)</> "
-                    f"with markers <b>{marker}</b>"
+                    f"<c1>{d.name}</c1> <fg=default>"
+                    f"(<c2>{d.pretty_constraint}</c2>)</> with markers <b>{marker}</b>"
                 )
 
             warnings = ", ".join(fmt_warning(d) for d in _deps[:-1])
@@ -673,7 +675,8 @@ class Provider:
                         dep_other.set_constraint(
                             dep_other.constraint.intersect(dep_any.constraint)
                         )
-                        # TODO: Setting _pretty_constraint can be removed once the following issue has been fixed
+                        # TODO: Setting _pretty_constraint can be removed once the
+                        # following issue has been fixed:
                         # https://github.com/python-poetry/poetry/issues/4589
                         dep_other._pretty_constraint = str(dep_other.constraint)
 
@@ -765,7 +768,10 @@ class Provider:
         elif message.startswith("derived:"):
             m = re.match(r"derived: (.+?) \((.+?)\)$", message)
             if m:
-                message = f"<fg=blue>derived</>: <c1>{m.group(1)}</c1> (<c2>{m.group(2)}</c2>)"
+                message = (
+                    f"<fg=blue>derived</>: <c1>{m.group(1)}</c1> "
+                    f"(<c2>{m.group(2)}</c2>)"
+                )
             else:
                 message = (
                     f"<fg=blue>derived</>: <c1>{message.split('derived: ')[1]}</c1>"
@@ -786,7 +792,10 @@ class Provider:
                     f"depends on <c1>{m.group(2)}</c1> (<c2>{m.group(3)}</c2>)"
                 )
             else:
-                message = f"<fg=red;options=bold>conflict</>: {message.split('conflict: ')[1]}"
+                message = (
+                    f"<fg=red;options=bold>conflict</>: "
+                    f"{message.split('conflict: ')[1]}"
+                )
 
         message = message.replace("! ", "<error>!</error> ")
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -23,6 +23,7 @@ from poetry.puzzle.provider import Provider
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
+
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.directory_dependency import DirectoryDependency
     from poetry.core.packages.file_dependency import FileDependency
@@ -30,7 +31,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
-
     from poetry.puzzle.transaction import Transaction
     from poetry.repositories import Pool
     from poetry.repositories import Repository
@@ -78,10 +78,12 @@ class Solver:
 
             if len(self._overrides) > 1:
                 self._provider.debug(
-                    f"Complete version solving took {end - start:.3f} seconds with {len(self._overrides)} overrides"
+                    f"Complete version solving took {end - start:.3f} seconds "
+                    f"with {len(self._overrides)} overrides"
                 )
                 self._provider.debug(
-                    f"Resolved with overrides: {', '.join(f'({b})' for b in self._overrides)}"
+                    f"Resolved with overrides: "
+                    f"{', '.join(f'({b})' for b in self._overrides)}"
                 )
 
         return Transaction(
@@ -140,7 +142,8 @@ class Solver:
         except SolveFailure as e:
             raise SolverProblemError(e)
 
-        # NOTE passing explicit empty array for seen to reset between invocations during update + install cycle
+        # NOTE passing explicit empty array for seen to reset between invocations
+        # during update + install cycle
         results = dict(
             depth_first_search(
                 PackageNode(self._package, packages, seen=[]), aggregate_package_nodes

--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -6,7 +6,6 @@ from typing import Tuple
 
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
-
     from poetry.installation.operations import OperationTypes
 
 
@@ -79,9 +78,9 @@ class Transaction:
                 current_package_names = {
                     current_package.name for current_package in self._current_packages
                 }
-                # We preserve pip/setuptools/wheel when not managed by poetry, this is done
-                # to avoid externally managed virtual environments causing unnecessary
-                # removals.
+                # We preserve pip/setuptools/wheel when not managed by poetry, this is
+                # done to avoid externally managed virtual environments causing
+                # unnecessary removals.
                 preserved_package_names = {
                     "pip",
                     "setuptools",

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -11,7 +11,6 @@ from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.utils.helpers import canonicalize_name
 from poetry.core.utils.helpers import module_name
-
 from poetry.repositories.repository import Repository
 from poetry.utils._compat import metadata
 
@@ -49,8 +48,8 @@ class InstalledRepository(Repository):
         paths = set()
 
         # we identify the candidate pth files to check, this is done so to handle cases
-        # where the pth file for foo-bar might have been installed as either foo-bar.pth or
-        # foo_bar.pth (expected) in either pure or platform lib directories.
+        # where the pth file for foo-bar might have been installed as either foo-bar.pth
+        # or foo_bar.pth (expected) in either pure or platform lib directories.
         candidates = itertools.product(
             {env.purelib, env.platlib},
             {name, module_name(name)},

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -21,14 +21,14 @@ import requests.exceptions
 from cachecontrol import CacheControl
 from cachecontrol.caches.file_cache import FileCache
 from cachy import CacheManager
+
+from poetry.config.config import Config
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
-
-from poetry.config.config import Config
 from poetry.inspection.info import PackageInfo
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.repositories.exceptions import PackageNotFound
@@ -342,7 +342,8 @@ class LegacyRepository(PyPiRepository):
         links = list(page.links_for_version(Version.parse(version)))
         if not links:
             raise PackageNotFound(
-                f'No valid distribution links found for package: "{name}" version: "{version}"'
+                "No valid distribution links found for package: "
+                f'"{name}" version: "{version}"'
             )
         urls = defaultdict(list)
         files = []

--- a/src/poetry/repositories/pool.py
+++ b/src/poetry/repositories/pool.py
@@ -11,7 +11,6 @@ from poetry.repositories.exceptions import PackageNotFound
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
     from poetry.repositories.repository import Repository
 
 

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -16,6 +16,7 @@ from cachecontrol.caches.file_cache import FileCache
 from cachecontrol.controller import logger as cache_control_logger
 from cachy import CacheManager
 from html5lib.html5parser import parse
+
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
@@ -24,7 +25,6 @@ from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
 from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.markers import parse_marker
-
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.remote_repository import RemoteRepository
@@ -121,7 +121,8 @@ class PyPiRepository(RemoteRepository):
             if not release:
                 # Bad release
                 self._log(
-                    f"No release information found for {dependency.name}-{version}, skipping",
+                    "No release information found for "
+                    f"{dependency.name}-{version}, skipping",
                     level="debug",
                 )
                 continue
@@ -130,7 +131,8 @@ class PyPiRepository(RemoteRepository):
                 package = Package(info["info"]["name"], version)
             except InvalidVersion:
                 self._log(
-                    f'Unable to parse version "{version}" for the {dependency.name} package, skipping',
+                    f'Unable to parse version "{version}" '
+                    f"for the {dependency.name} package, skipping",
                     level="debug",
                 )
                 continue
@@ -183,7 +185,8 @@ class PyPiRepository(RemoteRepository):
                 results.append(result)
             except InvalidVersion:
                 self._log(
-                    f'Unable to parse version "{version}" for the {name} package, skipping',
+                    f'Unable to parse version "{version}" '
+                    f"for the {name} package, skipping",
                     level="debug",
                 )
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -34,11 +34,11 @@ from packaging.tags import Tag
 from packaging.tags import interpreter_name
 from packaging.tags import interpreter_version
 from packaging.tags import sys_tags
+from virtualenv.seed.wheels.embed import get_embed_wheel
+
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
-from virtualenv.seed.wheels.embed import get_embed_wheel
-
 from poetry.locations import CACHE_DIR
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
@@ -51,8 +51,8 @@ from poetry.utils.helpers import temporary_directory
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-    from poetry.core.version.markers import BaseMarker
 
+    from poetry.core.version.markers import BaseMarker
     from poetry.poetry import Poetry
 
 
@@ -117,7 +117,8 @@ env = {
     "sys_platform": sys.platform,
     "version_info": tuple(sys.version_info),
     # Extra information
-    "interpreter_name": INTERPRETER_SHORT_NAMES.get(implementation_name, implementation_name),
+    "interpreter_name": \
+INTERPRETER_SHORT_NAMES.get(implementation_name, implementation_name),
     "interpreter_version": interpreter_version(),
 }
 
@@ -262,7 +263,8 @@ class SitePackages:
 
         if not results and strict:
             raise RuntimeError(
-                f'Unable to find a suitable destination for "{path}" in {paths_csv(self._candidates)}'
+                f"Unable to find a suitable destination "
+                f'for "{path}" in {paths_csv(self._candidates)}'
             )
 
         return results
@@ -416,7 +418,10 @@ class EnvCommandError(EnvError):
     def __init__(self, e: CalledProcessError, input: Optional[str] = None) -> None:
         self.e = e
 
-        message = f"Command {e.cmd} errored with the following return code {e.returncode}, and output: \n{decode(e.output)}"
+        message = (
+            f"Command {e.cmd} errored with the following return code {e.returncode}, "
+            f"and output: \n{decode(e.output)}"
+        )
         if input:
             message += f"input was : {input}"
         super().__init__(message)
@@ -450,6 +455,9 @@ class EnvManager:
     _env = None
 
     ENVS_FILE = "envs.toml"
+    VERSION_SCRIPT = (
+        "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\""
+    )
 
     def __init__(self, poetry: "Poetry") -> None:
         self._poetry = poetry
@@ -477,13 +485,7 @@ class EnvManager:
         try:
             python_version = decode(
                 subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            python,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
+                    list_to_shell_command([python, "-c", self.VERSION_SCRIPT]),
                     shell=True,
                 )
             )
@@ -723,13 +725,7 @@ class EnvManager:
         try:
             python_version = decode(
                 subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            python,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
+                    list_to_shell_command([python, "-c", self.VERSION_SCRIPT]),
                     shell=True,
                 )
             )
@@ -798,13 +794,7 @@ class EnvManager:
         if executable:
             python_patch = decode(
                 subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            executable,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
+                    list_to_shell_command([executable, "-c", self.VERSION_SCRIPT]),
                     shell=True,
                 ).strip()
             )
@@ -825,8 +815,9 @@ class EnvManager:
 
             io.write_line(
                 f"<warning>The currently activated Python version {python_patch} "
-                f"is not supported by the project ({self._poetry.package.python_versions}).\n"
-                "Trying to find and use a compatible version.</warning> "
+                f"is not supported by the project "
+                f"({self._poetry.package.python_versions}).\n"
+                f"Trying to find and use a compatible version.</warning> "
             )
 
             for python_to_try in sorted(
@@ -852,13 +843,7 @@ class EnvManager:
                 try:
                     python_patch = decode(
                         subprocess.check_output(
-                            list_to_shell_command(
-                                [
-                                    python,
-                                    "-c",
-                                    "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                                ]
-                            ),
+                            list_to_shell_command([python, "-c", self.VERSION_SCRIPT]),
                             stderr=subprocess.STDOUT,
                             shell=True,
                         ).strip()
@@ -904,7 +889,8 @@ class EnvManager:
             if force:
                 if not env.is_sane():
                     io.write_line(
-                        f"<warning>The virtual environment found in {env.path} seems to be broken.</warning>"
+                        f"<warning>The virtual environment found in {env.path} "
+                        f"seems to be broken.</warning>"
                     )
                 io.write_line(f"Recreating virtualenv <c1>{name}</> in {venv!s}")
                 self.remove_venv(venv)
@@ -965,7 +951,8 @@ class EnvManager:
             else flags.pop("no-setuptools", True)
         )
 
-        # we want wheels to be enabled when pip is required and it has not been explicitly disabled
+        # we want wheels to be enabled when pip is required and it has not been
+        # explicitly disabled
         flags["no-wheel"] = (
             not with_wheel
             if with_wheel is not None
@@ -1174,7 +1161,8 @@ class Env:
         """
         Path to current pip executable
         """
-        # we do not use as_posix() here due to issues with windows pathlib2 implementation
+        # we do not use as_posix() here due to issues with windows pathlib2
+        # implementation
         path = self._bin(self._pip_executable)
         if not Path(path).exists():
             return str(self.pip_embedded)

--- a/src/poetry/utils/exporter.py
+++ b/src/poetry/utils/exporter.py
@@ -6,7 +6,6 @@ from typing import Sequence
 from typing import Union
 
 from poetry.core.packages.utils.utils import path_to_url
-
 from poetry.utils._compat import decode
 
 

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -17,10 +17,10 @@ from typing import Optional
 
 
 if TYPE_CHECKING:
-    from poetry.core.packages.package import Package
     from requests import Session
 
     from poetry.config.config import Config
+    from poetry.core.packages.package import Package
 
 
 _canonicalize_regex = re.compile("[-_]+")

--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -6,7 +6,6 @@ from typing import Union
 
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import url_to_path
-
 from poetry.exceptions import PoetryException
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
@@ -28,9 +27,10 @@ def pip_install(
     path = url_to_path(path.url) if isinstance(path, Link) else path
     is_wheel = path.suffix == ".whl"
 
-    # We disable version check here as we are already pinning to version available in either the
-    # virtual environment or the virtualenv package embedded wheel. Version checks are a wasteful
-    # network call that adds a lot of wait time when installing a lot of packages.
+    # We disable version check here as we are already pinning to version available in
+    # either the virtual environment or the virtualenv package embedded wheel. Version
+    # checks are a wasteful network call that adds a lot of wait time when installing a
+    # lot of packages.
     args = ["install", "--disable-pip-version-check", "--prefix", str(environment.path)]
 
     if not is_wheel:
@@ -55,8 +55,9 @@ def pip_install(
         return environment.run_pip(*args)
     except EnvCommandError as e:
         if sys.version_info < (3, 7) and not is_wheel:
-            # Under certain Python3.6 installs vendored pip wheel does not contain zip-safe
-            # pep517 lib. In this cases we create an isolated ephemeral virtual environment.
+            # Under certain Python3.6 installs vendored pip wheel does not contain
+            # zip-safe pep517 lib. In this cases we create an isolated ephemeral
+            # virtual environment.
             with ephemeral_environment(
                 executable=environment.python, with_pip=True, with_setuptools=True
             ) as env:

--- a/src/poetry/version/version_selector.py
+++ b/src/poetry/version/version_selector.py
@@ -7,7 +7,6 @@ from poetry.core.semver.version import Version
 
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
-
     from poetry.repositories import Pool
 
 

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -4,7 +4,6 @@ from typing import List
 import pytest
 
 from poetry.core.semver.version import Version
-
 from tests.console.commands.env.helpers import check_output_wrapper
 
 

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -9,7 +9,6 @@ import tomlkit
 
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
-
 from poetry.utils.env import MockEnv
 from tests.console.commands.env.helpers import build_venv
 from tests.console.commands.env.helpers import check_output_wrapper

--- a/tests/console/commands/plugin/conftest.py
+++ b/tests/console/commands/plugin/conftest.py
@@ -2,9 +2,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.core.packages.package import Package
-
 from poetry.__version__ import __version__
+from poetry.core.packages.package import Package
 from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -191,15 +191,15 @@ poetry-plugin = "^1.2.3"
     tester.execute("poetry-plugin")
 
     expected = """\
-The following plugins are already present in the pyproject.toml file\
- and will be skipped:
+The following plugins are already present in the pyproject.toml file \
+and will be skipped:
 
   • poetry-plugin
 
-If you want to update it to the latest compatible version,\
- you can use `poetry plugin update package`.
-If you prefer to upgrade it to the latest available version,\
- you can use `poetry plugin add package@latest`.
+If you want to update it to the latest compatible version, \
+you can use `poetry plugin update package`.
+If you prefer to upgrade it to the latest available version, \
+you can use `poetry plugin add package@latest`.
 
 """
 

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -5,7 +5,6 @@ from typing import Union
 import pytest
 
 from poetry.core.packages.package import Package
-
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -192,12 +192,15 @@ poetry-plugin = "^1.2.3"
     tester.execute("poetry-plugin")
 
     expected = """\
-The following plugins are already present in the pyproject.toml file and will be skipped:
+The following plugins are already present in the pyproject.toml file\
+ and will be skipped:
 
   • poetry-plugin
 
-If you want to update it to the latest compatible version, you can use `poetry plugin update package`.
-If you prefer to upgrade it to the latest available version, you can use `poetry plugin add package@latest`.
+If you want to update it to the latest compatible version,\
+ you can use `poetry plugin update package`.
+If you prefer to upgrade it to the latest available version,\
+ you can use `poetry plugin add package@latest`.
 
 """
 

--- a/tests/console/commands/plugin/test_remove.py
+++ b/tests/console/commands/plugin/test_remove.py
@@ -3,9 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 import tomlkit
 
-from poetry.core.packages.package import Package
-
 from poetry.__version__ import __version__
+from poetry.core.packages.package import Package
 from poetry.layouts.layout import POETRY_DEFAULT
 
 

--- a/tests/console/commands/plugin/test_show.py
+++ b/tests/console/commands/plugin/test_show.py
@@ -4,8 +4,8 @@ from typing import Type
 import pytest
 
 from entrypoints import EntryPoint as _EntryPoint
-from poetry.core.packages.package import Package
 
+from poetry.core.packages.package import Package
 from poetry.factory import Factory
 from poetry.plugins.application_plugin import ApplicationPlugin
 from poetry.plugins.plugin import Plugin

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -4,11 +4,10 @@ from typing import Type
 
 import pytest
 
-from poetry.core.packages.package import Package
-from poetry.core.semver.version import Version
-
 from poetry.__version__ import __version__
 from poetry.console.exceptions import PoetrySimpleConsoleException
+from poetry.core.packages.package import Package
+from poetry.core.semver.version import Version
 from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -90,7 +90,7 @@ def test_source_add_existing(
     tester.execute(f"--default {source_existing.name} {source_existing.url}")
     assert (
         tester.io.fetch_output().strip()
-        == f"Source with name {source_existing.name} already exits. Updating."
+        == f"Source with name {source_existing.name} already exists. Updating."
     )
 
     poetry_with_source.pyproject.reload()

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -77,8 +77,8 @@ def test_source_add_error_default_and_secondary(tester: "CommandTester"):
 def test_source_add_error_pypi(tester: "CommandTester"):
     tester.execute("pypi https://test.pypi.org/simple/")
     expected = (
-        "Failed to validate addition of pypi:"
-        " The name [pypi] is reserved for repositories"
+        "Failed to validate addition of pypi: "
+        "The name [pypi] is reserved for repositories"
     )
     assert tester.io.fetch_error().strip() == expected
     assert tester.status_code == 1

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -76,10 +76,11 @@ def test_source_add_error_default_and_secondary(tester: "CommandTester"):
 
 def test_source_add_error_pypi(tester: "CommandTester"):
     tester.execute("pypi https://test.pypi.org/simple/")
-    assert (
-        tester.io.fetch_error().strip()
-        == "Failed to validate addition of pypi: The name [pypi] is reserved for repositories"
+    expected = (
+        "Failed to validate addition of pypi:"
+        " The name [pypi] is reserved for repositories"
     )
+    assert tester.io.fetch_error().strip() == expected
     assert tester.status_code == 1
 
 

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -19,8 +19,8 @@ def test_about(tester: "CommandTester"):
     expected = """\
 Poetry - Package Management for Python
 
-Poetry is a dependency manager tracking local dependencies\
- of your projects and libraries.
+Poetry is a dependency manager tracking local dependencies \
+of your projects and libraries.
 See https://github.com/python-poetry/poetry for more information.
 """
 

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -19,7 +19,8 @@ def test_about(tester: "CommandTester"):
     expected = """\
 Poetry - Package Management for Python
 
-Poetry is a dependency manager tracking local dependencies of your projects and libraries.
+Poetry is a dependency manager tracking local dependencies\
+ of your projects and libraries.
 See https://github.com/python-poetry/poetry for more information.
 """
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -76,8 +76,8 @@ def test_add_no_constraint_editable_error(
     tester.execute("-e cachy")
 
     expected = """
-Failed to add packages. Only vcs/path dependencies support editable installs.\
- cachy is neither.
+Failed to add packages. Only vcs/path dependencies support editable installs. \
+cachy is neither.
 
 No changes were applied.
 """
@@ -565,8 +565,8 @@ Writing lock file
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
-  • Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  • Installing demo \
+(0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == tester.io.fetch_output()
@@ -607,8 +607,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing cleo (0.6.5)
   • Installing pendulum (1.4.4)
   • Installing tomlkit (0.5.5)
-  • Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  • Installing demo \
+(0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
     # Order might be different, split into lines and compare the overall output.
     expected = set(expected.splitlines())
@@ -878,10 +878,10 @@ The following packages are already present in the pyproject.toml and will be ski
 
   • foo
 
-If you want to update it to the latest compatible version,\
- you can use `poetry update package`.
-If you prefer to upgrade it to the latest available version,\
- you can use `poetry add package@latest`.
+If you want to update it to the latest compatible version, \
+you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version, \
+you can use `poetry add package@latest`.
 """
 
     assert expected in tester.io.fetch_output()
@@ -1509,8 +1509,8 @@ Writing lock file
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
-  - Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  - Installing demo \
+(0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == old_tester.io.fetch_output()
@@ -1552,8 +1552,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing cleo (0.6.5)
   - Installing pendulum (1.4.4)
   - Installing tomlkit (0.5.5)
-  - Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  - Installing demo \
+(0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == old_tester.io.fetch_output()
@@ -1803,10 +1803,10 @@ The following packages are already present in the pyproject.toml and will be ski
 
   • foo
 
-If you want to update it to the latest compatible version,\
- you can use `poetry update package`.
-If you prefer to upgrade it to the latest available version,\
- you can use `poetry add package@latest`.
+If you want to update it to the latest compatible version, \
+you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version, \
+you can use `poetry add package@latest`.
 """
 
     assert expected in old_tester.io.fetch_output()

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -77,7 +77,8 @@ def test_add_no_constraint_editable_error(
     tester.execute("-e cachy")
 
     expected = """
-Failed to add packages. Only vcs/path dependencies support editable installs. cachy is neither.
+Failed to add packages. Only vcs/path dependencies support editable installs.\
+ cachy is neither.
 
 No changes were applied.
 """
@@ -565,7 +566,8 @@ Writing lock file
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
-  • Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  • Installing demo\
+ (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == tester.io.fetch_output()
@@ -590,7 +592,8 @@ def test_add_url_constraint_wheel_with_extras(
     repo.add_package(get_package("tomlkit", "0.5.5"))
 
     tester.execute(
-        "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl[foo,bar]"
+        "https://python-poetry.org/distributions/"
+        "demo-0.1.0-py2.py3-none-any.whl[foo,bar]"
     )
 
     expected = """\
@@ -605,7 +608,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing cleo (0.6.5)
   • Installing pendulum (1.4.4)
   • Installing tomlkit (0.5.5)
-  • Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  • Installing demo\
+ (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
     # Order might be different, split into lines and compare the overall output.
     expected = set(expected.splitlines())
@@ -617,7 +621,9 @@ Package operations: 4 installs, 0 updates, 0 removals
 
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
-        "url": "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl",
+        "url": (
+            "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        ),
         "extras": ["foo", "bar"],
     }
 
@@ -873,8 +879,10 @@ The following packages are already present in the pyproject.toml and will be ski
 
   • foo
 
-If you want to update it to the latest compatible version, you can use `poetry update package`.
-If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.
+If you want to update it to the latest compatible version,\
+ you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version,\
+ you can use `poetry add package@latest`.
 """
 
     assert expected in tester.io.fetch_output()
@@ -1502,7 +1510,8 @@ Writing lock file
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
-  - Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  - Installing demo\
+ (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == old_tester.io.fetch_output()
@@ -1528,7 +1537,8 @@ def test_add_url_constraint_wheel_with_extras_old_installer(
     repo.add_package(get_package("tomlkit", "0.5.5"))
 
     old_tester.execute(
-        "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl[foo,bar]"
+        "https://python-poetry.org/distributions/"
+        "demo-0.1.0-py2.py3-none-any.whl[foo,bar]"
     )
 
     expected = """\
@@ -1543,7 +1553,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing cleo (0.6.5)
   - Installing pendulum (1.4.4)
   - Installing tomlkit (0.5.5)
-  - Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+  - Installing demo\
+ (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
     assert expected == old_tester.io.fetch_output()
@@ -1554,7 +1565,9 @@ Package operations: 4 installs, 0 updates, 0 removals
 
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
-        "url": "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl",
+        "url": (
+            "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        ),
         "extras": ["foo", "bar"],
     }
 
@@ -1791,14 +1804,16 @@ The following packages are already present in the pyproject.toml and will be ski
 
   • foo
 
-If you want to update it to the latest compatible version, you can use `poetry update package`.
-If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.
+If you want to update it to the latest compatible version,\
+ you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version,\
+ you can use `poetry add package@latest`.
 """
 
     assert expected in old_tester.io.fetch_output()
 
 
-def test_add_should_work_when_adding_existing_package_with_latest_constraint_old_installer(
+def test_add_should_work_when_adding_existing_pckg_with_latest_constraint_old_installer(
     app: "PoetryTestApplication",
     repo: "TestRepository",
     installer: "NoopInstaller",

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.semver.version import Version
-
 from poetry.repositories.legacy_repository import LegacyRepository
 from tests.helpers import get_dependency
 from tests.helpers import get_package

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -39,8 +39,10 @@ def test_check_invalid(mocker: "MockerFixture", tester: "CommandTester"):
 
     expected = """\
 Error: 'description' is a required property
-Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
-Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
+Warning: A wildcard Python dependency is ambiguous.\
+ Consider specifying a more explicit one.
+Warning: The "pendulum" dependency specifies the "allows-prereleases" property,\
+ which is deprecated. Use "allow-prereleases" instead.
 """
 
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.core.pyproject.exceptions import PyProjectException
-
 from poetry.config.config_source import ConfigSource
+from poetry.core.pyproject.exceptions import PyProjectException
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -4,7 +4,6 @@ import pytest
 import tomlkit
 
 from poetry.core.packages.package import Package
-
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -67,7 +67,8 @@ sqlalchemy-wrap (2.1.7)
  Python wrapper for the CircleCI API
 
 sqlalchemy-nav (0.0.2)
- SQLAlchemy-Nav provides SQLAlchemy Mixins for creating navigation bars compatible with Bootstrap
+ SQLAlchemy-Nav provides SQLAlchemy Mixins for creating navigation bars\
+ compatible with Bootstrap
 
 sqlalchemy-repr (0.0.1)
  Automatically generates pretty repr of a SQLAlchemy model.

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -67,8 +67,8 @@ sqlalchemy-wrap (2.1.7)
  Python wrapper for the CircleCI API
 
 sqlalchemy-nav (0.0.2)
- SQLAlchemy-Nav provides SQLAlchemy Mixins for creating navigation bars\
- compatible with Bootstrap
+ SQLAlchemy-Nav provides SQLAlchemy Mixins for creating navigation bars \
+compatible with Bootstrap
 
 sqlalchemy-repr (0.0.1)
  Automatically generates pretty repr of a SQLAlchemy model.

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -386,8 +386,10 @@ def test_show_latest_decorated(
     tester.execute("--latest", decorated=True)
 
     expected = """\
-\033[36mcachy   \033[39m \033[39;1m0.1.0\033[39;22m \033[33m0.2.0\033[39m Cachy package
-\033[36mpendulum\033[39m \033[39;1m2.0.0\033[39;22m \033[31m2.0.1\033[39m Pendulum package
+\033[36mcachy   \033[39m \033[39;1m0.1.0\033[39;22m\
+ \033[33m0.2.0\033[39m Cachy package
+\033[36mpendulum\033[39m \033[39;1m2.0.0\033[39;22m\
+ \033[31m2.0.1\033[39m Pendulum package
 """
 
     assert expected == tester.io.fetch_output()
@@ -898,7 +900,9 @@ def test_show_outdated_git_dev_dependency(
                     "source": {
                         "type": "git",
                         "reference": "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
-                        "resolved_reference": "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+                        "resolved_reference": (
+                            "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+                        ),
                         "url": "https://github.com/demo/demo.git",
                     },
                 },

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -385,10 +385,10 @@ def test_show_latest_decorated(
     tester.execute("--latest", decorated=True)
 
     expected = """\
-\033[36mcachy   \033[39m \033[39;1m0.1.0\033[39;22m\
- \033[33m0.2.0\033[39m Cachy package
-\033[36mpendulum\033[39m \033[39;1m2.0.0\033[39;22m\
- \033[31m2.0.1\033[39m Pendulum package
+\033[36mcachy   \033[39m \033[39;1m0.1.0\033[39;22m \
+\033[33m0.2.0\033[39m Cachy package
+\033[36mpendulum\033[39m \033[39;1m2.0.0\033[39;22m \
+\033[31m2.0.1\033[39m Pendulum package
 """
 
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.packages.dependency_group import DependencyGroup
-
 from poetry.factory import Factory
 from tests.helpers import get_package
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -216,6 +216,7 @@ class TestRepository(Repository):
     def find_links_for_package(self, package: Package) -> List[Link]:
         return [
             Link(
-                f"https://foo.bar/files/{escape_name(package.name)}-{escape_version(package.version.text)}-py2.py3-none-any.whl"
+                f"https://foo.bar/files/{escape_name(package.name)}"
+                f"-{escape_version(package.version.text)}-py2.py3-none-any.whl"
             )
         ]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,14 +10,13 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from poetry.console.application import Application
 from poetry.core.masonry.utils.helpers import escape_name
 from poetry.core.masonry.utils.helpers import escape_version
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.toml.file import TOMLFile
 from poetry.core.vcs.git import ParsedUrl
-
-from poetry.console.application import Application
 from poetry.factory import Factory
 from poetry.installation.executor import Executor
 from poetry.packages import Locker
@@ -27,11 +26,11 @@ from poetry.utils._compat import WINDOWS
 
 
 if TYPE_CHECKING:
+    from tomlkit.toml_document import TOMLDocument
+
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.types import DependencyTypes
     from poetry.core.semver.version import Version
-    from tomlkit.toml_document import TOMLDocument
-
     from poetry.installation.operations import OperationTypes
     from poetry.poetry import Poetry
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -83,7 +83,8 @@ def test_get_cache_directory_for_link(config: "Config", config_cache_dir: Path):
     )
 
     expected = Path(
-        f"{config_cache_dir.as_posix()}/artifacts/ba/63/13/283a3b3b7f95f05e9e6f84182d276f7bb0951d5b0cc24422b33f7a4648"
+        f"{config_cache_dir.as_posix()}/artifacts/"
+        f"ba/63/13/283a3b3b7f95f05e9e6f84182d276f7bb0951d5b0cc24422b33f7a4648"
     )
 
     assert expected == directory

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.tags import Tag
-from poetry.core.packages.utils.link import Link
 
+from poetry.core.packages.utils.link import Link
 from poetry.installation.chef import Chef
 from poetry.utils.env import MockEnv
 

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -12,8 +12,8 @@ from typing import Union
 import pytest
 
 from packaging.tags import Tag
-from poetry.core.packages.package import Package
 
+from poetry.core.packages.package import Package
 from poetry.installation.chooser import Chooser
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -207,7 +207,10 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     package = Package("isort", "4.3.4")
     files = [
         {
-            "hash": "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+            "hash": (
+                "sha256:"
+                "b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8"
+            ),
             "filename": "isort-4.3.4.tar.gz",
         }
     ]
@@ -240,7 +243,10 @@ def test_chooser_throws_an_error_if_package_hashes_do_not_match(
     package = Package("isort", "4.3.4")
     files = [
         {
-            "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "hash": (
+                "sha256:"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
             "filename": "isort-4.3.4.tar.gz",
         }
     ]

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -252,23 +252,23 @@ def test_execute_works_with_ansi_output(
     env._run.assert_called_once()
 
     expected = [
-        "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install,"
-        " \x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
-        "\x1b[34;1m•\x1b[39;22m"
-        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
-        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
-        " \x1b[34mPending...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m"
-        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
-        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
-        " \x1b[34mDownloading...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m"
-        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
-        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
-        " \x1b[34mInstalling...\x1b[39m",
-        "\x1b[32;1m•\x1b[39;22m"
-        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
-        " (\x1b[39m\x1b[32m3.5.2\x1b[39m\x1b[39m)\x1b[39m",  # finished
+        "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install, "
+        "\x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
+        "\x1b[34;1m•\x1b[39;22m "
+        "\x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m "
+        "(\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: "
+        "\x1b[34mPending...\x1b[39m",
+        "\x1b[34;1m•\x1b[39;22m "
+        "\x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m "
+        "(\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: "
+        "\x1b[34mDownloading...\x1b[39m",
+        "\x1b[34;1m•\x1b[39;22m "
+        "\x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m "
+        "(\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: "
+        "\x1b[34mInstalling...\x1b[39m",
+        "\x1b[32;1m•\x1b[39;22m "
+        "\x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m "
+        "(\x1b[39m\x1b[32m3.5.2\x1b[39m\x1b[39m)\x1b[39m",  # finished
     ]
     output = io_decorated.fetch_output()
     # hint: use print(repr(output)) if you need to debug this

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -252,11 +252,23 @@ def test_execute_works_with_ansi_output(
     env._run.assert_called_once()
 
     expected = [
-        "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install, \x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mPending...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mDownloading...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mInstalling...\x1b[39m",
-        "\x1b[32;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m (\x1b[39m\x1b[32m3.5.2\x1b[39m\x1b[39m)\x1b[39m",  # finished
+        "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install,"
+        " \x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
+        "\x1b[34;1m•\x1b[39;22m"
+        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
+        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
+        " \x1b[34mPending...\x1b[39m",
+        "\x1b[34;1m•\x1b[39;22m"
+        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
+        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
+        " \x1b[34mDownloading...\x1b[39m",
+        "\x1b[34;1m•\x1b[39;22m"
+        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
+        " (\x1b[39m\x1b[39;1m3.5.2\x1b[39;22m\x1b[39m)\x1b[39m:"
+        " \x1b[34mInstalling...\x1b[39m",
+        "\x1b[32;1m•\x1b[39;22m"
+        " \x1b[39mInstalling \x1b[39m\x1b[36mpytest\x1b[39m\x1b[39m"
+        " (\x1b[39m\x1b[32m3.5.2\x1b[39m\x1b[39m)\x1b[39m",  # finished
     ]
     output = io_decorated.fetch_output()
     # hint: use print(repr(output)) if you need to debug this
@@ -542,7 +554,10 @@ def test_executor_should_use_cached_link_and_hash(
     package.files = [
         {
             "file": "demo-0.1.0-py2.py3-none-any.whl",
-            "hash": "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a",
+            "hash": (
+                "sha256:"
+                "70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a"
+            ),
         }
     ]
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -15,10 +15,10 @@ import pytest
 
 from cleo.formatters.style import Style
 from cleo.io.buffered_io import BufferedIO
+
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.utils._compat import PY36
-
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -497,7 +497,7 @@ def test_run_install_does_not_remove_locked_packages_if_installed_but_not_requir
     assert installer.executor.removals_count == 0
 
 
-def test_run_install_removes_locked_packages_if_installed_and_synchronization_is_required(
+def test_run_install_removes_locked_packages_if_installed_and_synchronization_is_required(  # noqa: E501
     installer: Installer,
     locker: Locker,
     repo: Repository,
@@ -1873,7 +1873,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
 @pytest.mark.skip(
     "This is not working at the moment due to limitations in the resolver"
 )
-def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(
+def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(  # noqa: E501
     installer: Installer,
     locker: Locker,
     repo: Repository,
@@ -1901,7 +1901,7 @@ def test_installer_test_solver_finds_compatible_package_for_dependency_python_no
     assert installer.executor.installations_count == 1
 
 
-def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency(
+def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency(  # noqa: E501
     installer: Installer,
     locker: Locker,
     repo: Repository,
@@ -1968,7 +1968,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
     assert installer.executor.removals_count == 0
 
 
-def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency_pypi_repository(
+def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency_pypi_repository(  # noqa: E501
     locker: Locker,
     repo: Repository,
     package: ProjectPackage,

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -18,11 +18,11 @@ from cleo.io.null_io import NullIO
 from cleo.io.outputs.buffered_output import BufferedOutput
 from cleo.io.outputs.output import Verbosity
 from deepdiff import DeepDiff
+
 from poetry.core.packages.dependency_group import DependencyGroup
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
-
 from poetry.factory import Factory
 from poetry.installation import Installer as BaseInstaller
 from poetry.installation.executor import Executor as BaseExecutor

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1532,7 +1532,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
 @pytest.mark.skip(
     "This is not working at the moment due to limitations in the resolver"
 )
-def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(
+def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(  # noqa: E501
     installer: Installer,
     locker: Locker,
     repo: Repository,
@@ -1562,7 +1562,7 @@ def test_installer_test_solver_finds_compatible_package_for_dependency_python_no
     assert len(installs) == 1
 
 
-def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency(
+def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency(  # noqa: E501
     installer: Installer,
     locker: Locker,
     repo: Repository,
@@ -1621,7 +1621,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
     assert len(installer.installer.removals) == 0
 
 
-def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency_pypi_repository(
+def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency_pypi_repository(  # noqa: E501
     locker: Locker,
     repo: Repository,
     package: ProjectPackage,

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -11,9 +11,9 @@ import pytest
 
 from cleo.io.null_io import NullIO
 from deepdiff import DeepDiff
+
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
-
 from poetry.factory import Factory
 from poetry.installation import Installer as BaseInstaller
 from poetry.installation.noop_installer import NoopInstaller

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-from poetry.core.packages.package import Package
 
+from poetry.core.packages.package import Package
 from poetry.installation.pip_installer import PipInstaller
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -102,9 +102,8 @@ def test_builder_installs_proper_files_for_standard_packages(
     assert dist_info.joinpath("entry_points.txt").exists()
 
     assert dist_info.joinpath("INSTALLER").read_text() == "poetry"
-    assert (
-        dist_info.joinpath("entry_points.txt").read_text()
-        == "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
+    assert dist_info.joinpath("entry_points.txt").read_text() == (
+        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
     )
 
     metadata = """\

--- a/tests/mixology/helpers.py
+++ b/tests/mixology/helpers.py
@@ -4,7 +4,6 @@ from typing import List
 from typing import Optional
 
 from poetry.core.packages.package import Package
-
 from poetry.factory import Factory
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.version_solver import VersionSolver

--- a/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
+++ b/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
@@ -1,5 +1,4 @@
 from poetry.core.packages.dependency import Dependency
-
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import NoVersionsCause

--- a/tests/mixology/solutions/solutions/test_python_requirement_solution.py
+++ b/tests/mixology/solutions/solutions/test_python_requirement_solution.py
@@ -1,6 +1,6 @@
 from cleo.io.buffered_io import BufferedIO
-from poetry.core.packages.dependency import Dependency
 
+from poetry.core.packages.dependency import Dependency
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import PythonCause

--- a/tests/mixology/solutions/solutions/test_python_requirement_solution.py
+++ b/tests/mixology/solutions/solutions/test_python_requirement_solution.py
@@ -24,8 +24,10 @@ The Python requirement can be specified via the `python` or `markers` properties
 For foo, a possible solution would be to set the `python` property to ">=3.6,<4.0"\
 """
     links = [
-        "https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies",
-        "https://python-poetry.org/docs/dependency-specification/#using-environment-markers",
+        "https://python-poetry.org/docs/dependency-specification/"
+        "#python-restricted-dependencies",
+        "https://python-poetry.org/docs/dependency-specification/"
+        "#using-environment-markers",
     ]
 
     assert title == solution.solution_title

--- a/tests/mixology/version_solver/conftest.py
+++ b/tests/mixology/version_solver/conftest.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-from poetry.core.packages.project_package import ProjectPackage
 
+from poetry.core.packages.project_package import ProjectPackage
 from poetry.puzzle.provider import Provider as BaseProvider
 from poetry.repositories import Pool
 from poetry.repositories import Repository

--- a/tests/mixology/version_solver/test_python_constraint.py
+++ b/tests/mixology/version_solver/test_python_constraint.py
@@ -19,7 +19,9 @@ def test_dependency_does_not_match_root_python_constraint(
 
     add_to_repo(repo, "foo", "1.0.0", python="<3.5")
 
-    error = """The current project's Python requirement (>=3.6,<4.0) is not compatible with some of the required packages Python requirement:
+    error = """\
+The current project's Python requirement (>=3.6,<4.0) is not compatible with\
+ some of the required packages Python requirement:
   - foo requires Python <3.5, so it will not be satisfied for Python >=3.6,<4.0
 
 Because no versions of foo match !=1.0.0

--- a/tests/mixology/version_solver/test_python_constraint.py
+++ b/tests/mixology/version_solver/test_python_constraint.py
@@ -20,8 +20,8 @@ def test_dependency_does_not_match_root_python_constraint(
     add_to_repo(repo, "foo", "1.0.0", python="<3.5")
 
     error = """\
-The current project's Python requirement (>=3.6,<4.0) is not compatible with\
- some of the required packages Python requirement:
+The current project's Python requirement (>=3.6,<4.0) is not compatible with \
+some of the required packages Python requirement:
   - foo requires Python <3.5, so it will not be satisfied for Python >=3.6,<4.0
 
 Because no versions of foo match !=1.0.0

--- a/tests/mixology/version_solver/test_unsolvable.py
+++ b/tests/mixology/version_solver/test_unsolvable.py
@@ -42,9 +42,12 @@ def test_no_version_that_matches_combined_constraints(
 
     error = """\
 Because foo (1.0.0) depends on shared (>=2.0.0 <3.0.0)
- and no versions of shared match >=2.9.0,<3.0.0, foo (1.0.0) requires shared (>=2.0.0,<2.9.0).
-And because bar (1.0.0) depends on shared (>=2.9.0 <4.0.0), bar (1.0.0) is incompatible with foo (1.0.0).
-So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed."""
+ and no versions of shared match >=2.9.0,<3.0.0, foo (1.0.0)\
+ requires shared (>=2.0.0,<2.9.0).
+And because bar (1.0.0) depends on shared (>=2.9.0 <4.0.0),\
+ bar (1.0.0) is incompatible with foo (1.0.0).
+So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed.\
+"""
 
     check_solver_result(root, provider, error=error)
 
@@ -62,8 +65,10 @@ def test_disjoint_constraints(
 
     error = """\
 Because bar (1.0.0) depends on shared (>3.0.0)
- and foo (1.0.0) depends on shared (<=2.0.0), bar (1.0.0) is incompatible with foo (1.0.0).
-So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed."""
+ and foo (1.0.0) depends on shared (<=2.0.0),\
+ bar (1.0.0) is incompatible with foo (1.0.0).
+So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed.\
+"""
 
     check_solver_result(root, provider, error=error)
     check_solver_result(root, provider, error=error)

--- a/tests/mixology/version_solver/test_unsolvable.py
+++ b/tests/mixology/version_solver/test_unsolvable.py
@@ -65,8 +65,8 @@ def test_disjoint_constraints(
 
     error = """\
 Because bar (1.0.0) depends on shared (>3.0.0)
- and foo (1.0.0) depends on shared (<=2.0.0),\
- bar (1.0.0) is incompatible with foo (1.0.0).
+ and foo (1.0.0) depends on shared (<=2.0.0), \
+bar (1.0.0) is incompatible with foo (1.0.0).
 So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed.\
 """
 

--- a/tests/mixology/version_solver/test_with_lock.py
+++ b/tests/mixology/version_solver/test_with_lock.py
@@ -73,7 +73,7 @@ def test_with_unrelated_locked_dependencies(
     )
 
 
-def test_unlocks_dependencies_if_necessary_to_ensure_that_a_new_dependency_is_statisfied(
+def test_unlocks_dependencies_if_necessary_to_ensure_that_a_new_dependency_is_satisfied(
     root: "ProjectPackage", provider: "Provider", repo: "Repository"
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -513,7 +513,7 @@ A = []
     assert expected == content
 
 
-def test_locker_should_neither_emit_warnings_nor_raise_error_for_lower_compatible_versions(
+def test_locker_should_neither_emit_warnings_nor_raise_error_for_lower_compatible_versions(  # noqa: E501
     locker: Locker, caplog: "LogCaptureFixture"
 ):
     current_version = Version.parse(Locker._VERSION)

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -10,7 +10,6 @@ import tomlkit
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.semver.version import Version
-
 from poetry.factory import Factory
 from poetry.packages.locker import Locker
 from tests.helpers import get_dependency

--- a/tests/puzzle/conftest.py
+++ b/tests/puzzle/conftest.py
@@ -12,8 +12,9 @@ except ImportError:
     import urlparse
 
 if TYPE_CHECKING:
-    from poetry.core.vcs import Git
     from pytest_mock import MockerFixture
+
+    from poetry.core.vcs import Git
 
 
 def mock_clone(self: "Git", source: str, dest: Path) -> None:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
+
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.vcs_dependency import VCSDependency
-
 from poetry.inspection.info import PackageInfo
 from poetry.puzzle.provider import Provider
 from poetry.repositories.pool import Pool

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1694,7 +1694,7 @@ def test_solver_ignores_dependencies_with_incompatible_python_full_version_marke
     package_a.add_dependency(
         Dependency.create_from_pep_508(
             'B (<2.0); platform_python_implementation == "PyPy"'
-            'and python_full_version < "2.7.9"'
+            ' and python_full_version < "2.7.9"'
         )
     )
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -9,12 +9,12 @@ from typing import Type
 import pytest
 
 from cleo.io.null_io import NullIO
+
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.version.markers import parse_marker
-
 from poetry.factory import Factory
 from poetry.puzzle import Solver
 from poetry.puzzle.exceptions import SolverProblemError

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -964,7 +964,7 @@ def test_solver_with_dependency_in_both_default_and_dev_dependencies(
     assert a.category == "main"
 
 
-def test_solver_with_dependency_in_both_main_and_dev_dependencies_with_one_more_dependent(
+def test_solver_with_dependency_in_both_main_and_dev_dependencies_with_one_more_dependent(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     package.add_dependency(Factory.create_dependency("A", "*"))
@@ -1466,7 +1466,7 @@ def test_solver_can_resolve_git_dependencies_with_ref(
     assert op.package.source_resolved_reference.startswith("9cf87a2")
 
 
-def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible(
+def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     solver.provider.set_package_python_versions("~2.7 || ^3.4")
@@ -1484,7 +1484,7 @@ def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requir
     check_solver_result(transaction, [{"job": "install", "package": package_a}])
 
 
-def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible_multiple(
+def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible_multiple(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     solver.provider.set_package_python_versions("~2.7 || ^3.4")
@@ -1516,7 +1516,7 @@ def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requir
     )
 
 
-def test_solver_triggers_conflict_for_dependency_python_not_fully_compatible_with_package_python(
+def test_solver_triggers_conflict_for_dependency_python_not_fully_compatible_with_package_python(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     solver.provider.set_package_python_versions("~2.7 || ^3.4")
@@ -1533,7 +1533,7 @@ def test_solver_triggers_conflict_for_dependency_python_not_fully_compatible_wit
         solver.solve()
 
 
-def test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(
+def test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     solver.provider.set_package_python_versions("~2.7 || ^3.4")
@@ -1555,7 +1555,7 @@ def test_solver_finds_compatible_package_for_dependency_python_not_fully_compati
     check_solver_result(transaction, [{"job": "install", "package": package_a100}])
 
 
-def test_solver_does_not_trigger_new_resolution_on_duplicate_dependencies_if_only_extras(
+def test_solver_does_not_trigger_new_resolution_on_duplicate_dependencies_if_only_extras(  # noqa: E501
     solver: Solver, repo: Repository, package: Package
 ):
     dep1 = Dependency.create_from_pep_508('B (>=1.0); extra == "foo"')
@@ -1693,7 +1693,8 @@ def test_solver_ignores_dependencies_with_incompatible_python_full_version_marke
     package_a = get_package("A", "1.0.0")
     package_a.add_dependency(
         Dependency.create_from_pep_508(
-            'B (<2.0); platform_python_implementation == "PyPy" and python_full_version < "2.7.9"'
+            'B (<2.0); platform_python_implementation == "PyPy"'
+            'and python_full_version < "2.7.9"'
         )
     )
 
@@ -1835,7 +1836,9 @@ def test_solver_git_dependencies_short_hash_update_skipped(
                     source_type="git",
                     source_url="https://github.com/demo/demo.git",
                     source_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
-                    source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+                    source_resolved_reference=(
+                        "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+                    ),
                 ),
                 "skipped": True,
             },

--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -4,7 +4,6 @@ from typing import Dict
 from typing import List
 
 from poetry.core.packages.package import Package
-
 from poetry.puzzle.transaction import Transaction
 
 

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -13,8 +13,9 @@ from tests.compat import zipp
 
 
 if TYPE_CHECKING:
-    from poetry.core.packages.package import Package
     from pytest_mock.plugin import MockerFixture
+
+    from poetry.core.packages.package import Package
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 ENV_DIR = (FIXTURES_DIR / "installed").resolve()

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -10,7 +10,6 @@ import pytest
 import requests
 
 from poetry.core.packages.dependency import Dependency
-
 from poetry.factory import Factory
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -283,11 +283,17 @@ def test_get_package_retrieves_non_sha256_hashes():
     expected = [
         {
             "file": "ipython-7.5.0-py3-none-any.whl",
-            "hash": "sha256:78aea20b7991823f6a32d55f4e963a61590820e43f666ad95ad07c7f0c704efa",
+            "hash": (
+                "sha256:"
+                "78aea20b7991823f6a32d55f4e963a61590820e43f666ad95ad07c7f0c704efa"
+            ),
         },
         {
             "file": "ipython-7.5.0.tar.gz",
-            "hash": "sha256:e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26",
+            "hash": (
+                "sha256:"
+                "e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26"
+            ),
         },
     ]
 
@@ -306,11 +312,17 @@ def test_get_package_retrieves_non_sha256_hashes_mismatching_known_hash():
         },
         {
             "file": "ipython-5.7.0-py3-none-any.whl",
-            "hash": "sha256:fc0464e68f9c65cd8c453474b4175432cc29ecb6c83775baedf6dbfcee9275ab",
+            "hash": (
+                "sha256:"
+                "fc0464e68f9c65cd8c453474b4175432cc29ecb6c83775baedf6dbfcee9275ab"
+            ),
         },
         {
             "file": "ipython-5.7.0.tar.gz",
-            "hash": "sha256:8db43a7fb7619037c98626613ff08d03dda9d5d12c84814a4504c78c0da8323c",
+            "hash": (
+                "sha256:"
+                "8db43a7fb7619037c98626613ff08d03dda9d5d12c84814a4504c78c0da8323c"
+            ),
         },
     ]
 
@@ -322,12 +334,16 @@ def test_get_package_retrieves_packages_with_no_hashes():
 
     package = repo.package("jupyter", "1.0.0")
 
-    assert [
+    expected = [
         {
             "file": "jupyter-1.0.0.tar.gz",
-            "hash": "sha256:d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f",
+            "hash": (
+                "sha256:"
+                "d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f"
+            ),
         }
-    ] == package.files
+    ]
+    assert expected == package.files
 
 
 class MockHttpRepository(LegacyRepository):

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -9,10 +9,10 @@ from typing import Optional
 
 import pytest
 
-from poetry.core.packages.dependency import Dependency
 from requests.exceptions import TooManyRedirects
 from requests.models import Response
 
+from poetry.core.packages.dependency import Dependency
 from poetry.factory import Factory
 from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.utils._compat import encode

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from entrypoints import EntryPoint
+
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.toml.file import TOMLFile
-
 from poetry.factory import Factory
 from poetry.plugins.plugin import Plugin
 from poetry.repositories.legacy_repository import LegacyRepository

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -101,9 +101,9 @@ def test_create_poetry():
     functools32 = dependencies["functools32"]
     assert functools32.name == "functools32"
     assert functools32.pretty_constraint == "^3.2.3"
-    assert (
-        str(functools32.marker)
-        == 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
+    assert str(functools32.marker) == (
+        'python_version ~= "2.7" and sys_platform == "win32"'
+        ' or python_version in "3.4 3.5"'
     )
 
     assert "db" in package.extras

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -795,7 +795,7 @@ def test_call_no_input_with_called_process_error(
     subprocess.call.assert_called_once()
 
 
-def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_ones_first(
+def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_first(
     manager: EnvManager,
     poetry: "Poetry",
     config: "Config",

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -795,7 +795,7 @@ def test_call_no_input_with_called_process_error(
     subprocess.call.assert_called_once()
 
 
-def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_first(
+def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_ones_first(  # noqa: E501
     manager: EnvManager,
     poetry: "Poetry",
     config: "Config",

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -16,9 +16,9 @@ import pytest
 import tomlkit
 
 from cleo.io.null_io import NullIO
+
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
-
 from poetry.factory import Factory
 from poetry.utils._compat import WINDOWS
 from poetry.utils.env import GET_BASE_PREFIX

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -456,7 +456,7 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
         ),
         "d": Dependency.create_from_pep_508(
             "d==0.0.1 ; platform_system == 'Windows' and python_version < '3.7'"
-            "or sys_platform == 'win32' and python_version < '3.7'"
+            " or sys_platform == 'win32' and python_version < '3.7'"
         ),
     }
 
@@ -574,7 +574,7 @@ foo==1.2.3 \\
     assert expected == content
 
 
-def test_exporter_can_export_requirements_txt_with_standard_pckgs_and_hashes_disabled(
+def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes_disabled(  # noqa: E501
     tmp_dir: str, poetry: "Poetry"
 ):
     poetry.locker.mock_lock_data(
@@ -1245,10 +1245,10 @@ def test_exporter_can_export_requirements_txt_with_directory_packages_and_marker
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    expected = (
-        f"foo @ {working_directory.as_uri()}/tests/fixtures/"
-        f'sample_project ; python_version < "3.7"\n'
-    )
+    expected = f"""\
+foo @ {working_directory.as_uri()}/tests/fixtures/sample_project ; \
+python_version < "3.7"
+"""
 
     assert expected == content
 
@@ -1331,10 +1331,10 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    expected = (
-        f"foo @ {working_directory.as_uri()}/tests/fixtures/distributions/"
-        f'demo-0.1.0.tar.gz ; python_version < "3.7"\n'
-    )
+    expected = f"""\
+foo @ {working_directory.as_uri()}/tests/fixtures/distributions/demo-0.1.0.tar.gz ; \
+python_version < "3.7"
+"""
 
     assert expected == content
 

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -14,7 +14,6 @@ import pytest
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.toml.file import TOMLFile
-
 from poetry.factory import Factory
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories.legacy_repository import LegacyRepository

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -276,7 +276,8 @@ def test_exporter_can_export_requirements_txt_poetry(tmp_dir: str, poetry: "Poet
         content = f.read()
 
     # The dependency graph:
-    # junit-xml 1.9 Creates JUnit XML test result documents that can be read by tools such as Jenkins
+    # junit-xml 1.9 Creates JUnit XML test result documents that can be read by tools
+    # such as Jenkins
     # └── six *
     # poetry 1.1.4 Python dependency management and packaging made easy.
     # ├── keyring >=21.2.0,<22.0.0
@@ -364,10 +365,12 @@ def test_exporter_can_export_requirements_txt_pyinstaller(
         content = f.read()
 
     # Rationale for the results:
-    #  * PyInstaller has an explicit dependency on altgraph, so it must always be installed.
+    #  * PyInstaller has an explicit dependency on altgraph, so it must always
+    #        be installed.
     #  * PyInstaller requires macholib on Darwin, which in turn requires altgraph.
     # The dependency graph:
-    # pyinstaller 4.0 PyInstaller bundles a Python application and all its dependencies into a single package.
+    # pyinstaller 4.0 PyInstaller bundles a Python application and all its dependencies
+    # into a single package.
     # ├── altgraph *
     # ├── macholib >=1.8 -- only on Darwin
     # │   └── altgraph >=0.15
@@ -453,7 +456,8 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
             "c==7.8.9 ; sys_platform == 'win32' and python_version < '3.7'"
         ),
         "d": Dependency.create_from_pep_508(
-            "d==0.0.1 ; platform_system == 'Windows' and python_version < '3.7' or sys_platform == 'win32' and python_version < '3.7'"
+            "d==0.0.1 ; platform_system == 'Windows' and python_version < '3.7'"
+            "or sys_platform == 'win32' and python_version < '3.7'"
         ),
     }
 
@@ -571,7 +575,7 @@ foo==1.2.3 \\
     assert expected == content
 
 
-def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes_disabled(
+def test_exporter_can_export_requirements_txt_with_standard_pckgs_and_hashes_disabled(
     tmp_dir: str, poetry: "Poetry"
 ):
     poetry.locker.mock_lock_data(
@@ -1158,7 +1162,10 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
                     "python-versions": "*",
                     "source": {
                         "type": "directory",
-                        "url": "tests/fixtures/sample_project/../project_with_nested_local/bar",
+                        "url": (
+                            "tests/fixtures/sample_project/../"
+                            "project_with_nested_local/bar"
+                        ),
                         "reference": "",
                     },
                 },
@@ -1170,7 +1177,10 @@ def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
                     "python-versions": "*",
                     "source": {
                         "type": "directory",
-                        "url": "tests/fixtures/sample_project/../project_with_nested_local/bar/..",
+                        "url": (
+                            "tests/fixtures/sample_project/../"
+                            "project_with_nested_local/bar/.."
+                        ),
                         "reference": "",
                     },
                 },
@@ -1236,9 +1246,10 @@ def test_exporter_can_export_requirements_txt_with_directory_packages_and_marker
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    expected = f"""\
-foo @ {working_directory.as_uri()}/tests/fixtures/sample_project ; python_version < "3.7"
-"""
+    expected = (
+        f"foo @ {working_directory.as_uri()}/tests/fixtures/"
+        f'sample_project ; python_version < "3.7"\n'
+    )
 
     assert expected == content
 
@@ -1321,9 +1332,10 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    expected = f"""\
-foo @ {working_directory.as_uri()}/tests/fixtures/distributions/demo-0.1.0.tar.gz ; python_version < "3.7"
-"""
+    expected = (
+        f"foo @ {working_directory.as_uri()}/tests/fixtures/distributions/"
+        f'demo-0.1.0.tar.gz ; python_version < "3.7"\n'
+    )
 
     assert expected == content
 

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -4,7 +4,6 @@ from typing import List
 import pytest
 
 from poetry.core.packages.package import Package
-
 from poetry.factory import Factory
 from poetry.utils.extras import get_extra_package_names
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -27,7 +27,8 @@ msgpack-python>=0.5.0.0,<0.6.0.0
 pyparsing>=2.2.0.0,<3.0.0.0
 requests-toolbelt>=0.8.0.0,<0.9.0.0
 
-[:(python_version >= "2.7.0.0" and python_version < "2.8.0.0") or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")]
+[:(python_version >= "2.7.0.0" and python_version < "2.8.0.0")\
+ or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")]
 typing>=3.6.0.0,<4.0.0.0
 
 [:python_version >= "2.7.0.0" and python_version < "2.8.0.0"]
@@ -38,7 +39,8 @@ pathlib2>=2.3.0.0,<3.0.0.0
 zipfile36>=0.1.0.0,<0.2.0.0
 
 [dev]
-isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
+isort@ git+git://github.com/timothycrosley/isort.git\
+@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
 """
     result = parse_requires(requires)
     expected = [
@@ -55,11 +57,17 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
         "msgpack-python>=0.5.0.0,<0.6.0.0",
         "pyparsing>=2.2.0.0,<3.0.0.0",
         "requests-toolbelt>=0.8.0.0,<0.9.0.0",
-        'typing>=3.6.0.0,<4.0.0.0 ; (python_version >= "2.7.0.0" and python_version < "2.8.0.0") or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
-        'virtualenv>=15.2.0.0,<16.0.0.0 ; python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        'pathlib2>=2.3.0.0,<3.0.0.0 ; python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        'zipfile36>=0.1.0.0,<0.2.0.0 ; python_version >= "3.4.0.0" and python_version < "3.6.0.0"',
-        'isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort ; extra == "dev"',
+        "typing>=3.6.0.0,<4.0.0.0 ;"
+        ' (python_version >= "2.7.0.0" and python_version < "2.8.0.0")'
+        ' or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
+        "virtualenv>=15.2.0.0,<16.0.0.0 ;"
+        ' python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
+        "pathlib2>=2.3.0.0,<3.0.0.0 ;"
+        ' python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
+        "zipfile36>=0.1.0.0,<0.2.0.0 ;"
+        ' python_version >= "3.4.0.0" and python_version < "3.6.0.0"',
+        "isort@ git+git://github.com/timothycrosley/isort.git"
+        '@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort ; extra == "dev"',
     ]
     assert result == expected
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,8 +26,8 @@ msgpack-python>=0.5.0.0,<0.6.0.0
 pyparsing>=2.2.0.0,<3.0.0.0
 requests-toolbelt>=0.8.0.0,<0.9.0.0
 
-[:(python_version >= "2.7.0.0" and python_version < "2.8.0.0")\
- or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")]
+[:(python_version >= "2.7.0.0" and python_version < "2.8.0.0") or \
+(python_version >= "3.4.0.0" and python_version < "3.5.0.0")]
 typing>=3.6.0.0,<4.0.0.0
 
 [:python_version >= "2.7.0.0" and python_version < "2.8.0.0"]
@@ -56,15 +56,15 @@ isort@ git+git://github.com/timothycrosley/isort.git\
         "msgpack-python>=0.5.0.0,<0.6.0.0",
         "pyparsing>=2.2.0.0,<3.0.0.0",
         "requests-toolbelt>=0.8.0.0,<0.9.0.0",
-        "typing>=3.6.0.0,<4.0.0.0 ;"
-        ' (python_version >= "2.7.0.0" and python_version < "2.8.0.0")'
-        ' or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
-        "virtualenv>=15.2.0.0,<16.0.0.0 ;"
-        ' python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        "pathlib2>=2.3.0.0,<3.0.0.0 ;"
-        ' python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        "zipfile36>=0.1.0.0,<0.2.0.0 ;"
-        ' python_version >= "3.4.0.0" and python_version < "3.6.0.0"',
+        "typing>=3.6.0.0,<4.0.0.0 ; "
+        '(python_version >= "2.7.0.0" and python_version < "2.8.0.0") or '
+        '(python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
+        "virtualenv>=15.2.0.0,<16.0.0.0 ; "
+        'python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
+        "pathlib2>=2.3.0.0,<3.0.0.0 ; "
+        'python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
+        "zipfile36>=0.1.0.0,<0.2.0.0 ; "
+        'python_version >= "3.4.0.0" and python_version < "3.6.0.0"',
         "isort@ git+git://github.com/timothycrosley/isort.git"
         '@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort ; extra == "dev"',
     ]

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from poetry.core.utils.helpers import parse_requires
-
 from poetry.utils.helpers import get_cert
 from poetry.utils.helpers import get_client_cert
 

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -6,7 +6,6 @@ import pytest
 
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import path_to_url
-
 from poetry.utils.pip import pip_install
 
 

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -5,7 +5,6 @@ from typing import Callable
 import pytest
 
 from poetry.core.version.exceptions import InvalidVersion
-
 from poetry.utils.setup_reader import SetupReader
 
 


### PR DESCRIPTION
Resolves: #4776

Hi! This is my first PR for `poetry`; please let me know how I can improve my work.

Because of the nature of the issue being fixed (linting rules), this PR touches a lot of files. There are no functional changes, however, so I figured it would be OK for a single PR. Let me know if you would like me to break it up into smaller PRs (an option would be `tests` first, then `src`, for example).

# Changes

* Updated `.flake8` to remove the `E501` error (line too long) from the list of ignored warnings.
* Updated long strings all across the code base (`src` and `tests`) to comply to the line length of 88. See below for more details.
* Explicitly ignore the `E501` error for some long test function names and the occasional in-line comment with a URL.
* Fixed a typo in `src/poetry/console/commands/source/add.py`: "already exits" -> "already exists"
* Fixed a few more rare typos in docs/comments.
* For some reason, `isort` formatted some imports, notably it sees `poetry.core` imports as local imports. Not sure why this is - I am probably doing something wrong?

# String wrapping approach

I try to be consistent with the formatting I found elsewhere in the code base.

For long regular strings, I wrap them using implicit string concatenation, with trailing space and if it's an f-string, an 'f' in front of each line:

```python
# Original
long_string = f"This string is way too long for a code base with a maximum character limit of {88}."

# Wrapped
long_string = (
    f"This string is way too long for a code base "
    f"with a maximum character limit of {88}."
)
```

For multi-line strings, I use backslash breaks with trailing space:
```python
# Original
long_string = """\
This string is way too long for a code base with a maximum character limit of 88.
"""

# Wrapped
long_string = """\
This string is way too long for a code base \
with a maximum character limit of 88.
"""
```
